### PR TITLE
feat: Add arrow key navigation support for image browsing, including option…

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,17 @@ Logs will be saved to `~/.photosort_logs/photosort_app.log`.
 * **Single View:** `F1`
 * **Side by Side View:** `F2`
 
+**Arrow Key Navigation**
+
+* **Navigate Between Images:** `Arrow Keys` (←, →, ↑, ↓) or `H`, `J`, `K`, `L` (Vim-style)
+  * Automatically skips files marked for deletion (with "(DELETED)" in filename)
+  * Left/Right (or H/L): Navigate within the same group/folder
+  * Up/Down (or K/J): Navigate sequentially through all visible images
+* **Navigate Including Deleted Images:** `Ctrl+Arrow Keys` or `Ctrl+H/J/K/L`
+  * Same navigation as above, but **does not skip** files marked for deletion
+  * Useful for reviewing files before committing deletions
+  * Allows access to deleted files for comparison or unmarking
+
 **Image Rotation**
 
 * **Auto Rotate Images:** `Ctrl+R`

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Logs will be saved to `~/.photosort_logs/photosort_app.log`.
   * Automatically skips files marked for deletion (with "(DELETED)" in filename)
   * Left/Right (or H/L): Navigate within the same group/folder
   * Up/Down (or K/J): Navigate sequentially through all visible images
-* **Navigate Including Deleted Images:** `Ctrl+Arrow Keys` or `Ctrl+H/J/K/L`
+* **Navigate Including Deleted Images:** `Ctrl+Arrow Keys` or `Ctrl+H/J/K/L` (or `Cmd+Arrow Keys` / `Cmd+H/J/K/L` on macOS)
   * Same navigation as above, but **does not skip** files marked for deletion
   * Useful for reviewing files before committing deletions
   * Allows access to deleted files for comparison or unmarking

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -197,6 +197,17 @@ class MainWindow(QMainWindow):
         self.blur_detection_threshold = DEFAULT_BLUR_DETECTION_THRESHOLD
         self.rotation_suggestions = {}
 
+        self.navigation_keys = {
+            Qt.Key.Key_Left: ("LEFT/H", self._navigate_left_in_group),
+            Qt.Key.Key_H: ("LEFT/H", self._navigate_left_in_group),
+            Qt.Key.Key_Right: ("RIGHT/L", self._navigate_right_in_group),
+            Qt.Key.Key_L: ("RIGHT/L", self._navigate_right_in_group),
+            Qt.Key.Key_Up: ("UP/K", self._navigate_up_sequential),
+            Qt.Key.Key_K: ("UP/K", self._navigate_up_sequential),
+            Qt.Key.Key_Down: ("DOWN/J", self._navigate_down_sequential),
+            Qt.Key.Key_J: ("DOWN/J", self._navigate_down_sequential),
+        }
+
         self.filter_combo = QComboBox()
         self.filter_combo.addItems(
             [
@@ -3286,29 +3297,12 @@ class MainWindow(QMainWindow):
         the 'skip deleted' logic.
         Returns True if the key was handled, False otherwise.
         """
-        if key == Qt.Key.Key_Left or key == Qt.Key.Key_H:
+        if key in self.navigation_keys:
+            direction_name, nav_func = self.navigation_keys[key]
             logger.debug(
-                "Modified arrow key pressed: LEFT/H - Starting navigation (bypass deleted)"
+                f"Modified arrow key pressed: {direction_name} - Starting navigation (bypass deleted)"
             )
-            self._navigate_left_in_group(skip_deleted=False)
-            return True
-        if key == Qt.Key.Key_Right or key == Qt.Key.Key_L:
-            logger.debug(
-                "Modified arrow key pressed: RIGHT/L - Starting navigation (bypass deleted)"
-            )
-            self._navigate_right_in_group(skip_deleted=False)
-            return True
-        if key == Qt.Key.Key_Up or key == Qt.Key.Key_K:
-            logger.debug(
-                "Modified arrow key pressed: UP/K - Starting navigation (bypass deleted)"
-            )
-            self._navigate_up_sequential(skip_deleted=False)
-            return True
-        if key == Qt.Key.Key_Down or key == Qt.Key.Key_J:
-            logger.debug(
-                "Modified arrow key pressed: DOWN/J - Starting navigation (bypass deleted)"
-            )
-            self._navigate_down_sequential(skip_deleted=False)
+            nav_func(skip_deleted=False)
             return True
         return False
 
@@ -3388,29 +3382,12 @@ class MainWindow(QMainWindow):
                         logger.debug(
                             f"Unmodified/keypad key detected: {key} (modifiers: {modifiers})"
                         )
-                        if key == Qt.Key.Key_Left or key == Qt.Key.Key_H:
+                        if key in self.navigation_keys:
+                            direction_name, nav_func = self.navigation_keys[key]
                             logger.debug(
-                                f"Arrow key pressed: LEFT/H - Starting navigation"
+                                f"Arrow key pressed: {direction_name} - Starting navigation"
                             )
-                            self._navigate_left_in_group(skip_deleted=True)
-                            return True
-                        if key == Qt.Key.Key_Right or key == Qt.Key.Key_L:
-                            logger.debug(
-                                f"Arrow key pressed: RIGHT/L - Starting navigation"
-                            )
-                            self._navigate_right_in_group(skip_deleted=True)
-                            return True
-                        if key == Qt.Key.Key_Up or key == Qt.Key.Key_K:
-                            logger.debug(
-                                f"Arrow key pressed: UP/K - Starting navigation"
-                            )
-                            self._navigate_up_sequential(skip_deleted=True)
-                            return True
-                        if key == Qt.Key.Key_Down or key == Qt.Key.Key_J:
-                            logger.debug(
-                                f"Arrow key pressed: DOWN/J - Starting navigation"
-                            )
-                            self._navigate_down_sequential(skip_deleted=True)
+                            nav_func(skip_deleted=True)
                             return True
                         if key == Qt.Key.Key_Delete or key == Qt.Key.Key_Backspace:
                             self._handle_delete_action()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -3374,12 +3374,9 @@ class MainWindow(QMainWindow):
                         Qt.KeyboardModifier.ControlModifier,
                         Qt.KeyboardModifier.MetaModifier,
                     )
-                    has_control_or_meta = bool(
-                        modifiers
-                        & (
-                            Qt.KeyboardModifier.ControlModifier
-                            | Qt.KeyboardModifier.MetaModifier
-                        )
+                    has_control_or_meta = modifiers & (
+                        Qt.KeyboardModifier.ControlModifier
+                        | Qt.KeyboardModifier.MetaModifier
                     )
 
                     # Rating shortcuts (Ctrl/Cmd + 0-5) - MUST be an exact modifier match.

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -3350,7 +3350,7 @@ class MainWindow(QMainWindow):
                         rating = key - Qt.Key.Key_0
                         self._apply_rating_to_selection(rating)
                         return True
-                    
+
                     # --- Custom navigation for UNMODIFIED arrow keys ---
                     if is_unmodified_or_keypad:
                         logger.debug(

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -3300,7 +3300,8 @@ class MainWindow(QMainWindow):
             direction_name, nav_func = self.navigation_keys[key]
             skip_deleted = not is_modified
 
-            log_prefix = "Modified arrow" if is_modified else "Arrow"
+            key_type = "arrow" if direction_name in ["Up", "Down", "Left", "Right"] else "navigation"
+            log_prefix = f"Modified {key_type}" if is_modified else key_type.capitalize()
             log_suffix = " (bypass deleted)" if is_modified else ""
             logger.debug(
                 f"{log_prefix} key pressed: {direction_name} - Starting navigation{log_suffix}"

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -3280,6 +3280,38 @@ class MainWindow(QMainWindow):
 
         return False
 
+    def _handle_modified_arrow_key_navigation(self, key: int) -> bool:
+        """
+        Handles arrow key navigation when Ctrl or Cmd is pressed, which bypasses
+        the 'skip deleted' logic.
+        Returns True if the key was handled, False otherwise.
+        """
+        if key == Qt.Key.Key_Left or key == Qt.Key.Key_H:
+            logger.debug(
+                "Modified arrow key pressed: LEFT/H - Starting navigation (bypass deleted)"
+            )
+            self._navigate_left_in_group(skip_deleted=False)
+            return True
+        if key == Qt.Key.Key_Right or key == Qt.Key.Key_L:
+            logger.debug(
+                "Modified arrow key pressed: RIGHT/L - Starting navigation (bypass deleted)"
+            )
+            self._navigate_right_in_group(skip_deleted=False)
+            return True
+        if key == Qt.Key.Key_Up or key == Qt.Key.Key_K:
+            logger.debug(
+                "Modified arrow key pressed: UP/K - Starting navigation (bypass deleted)"
+            )
+            self._navigate_up_sequential(skip_deleted=False)
+            return True
+        if key == Qt.Key.Key_Down or key == Qt.Key.Key_J:
+            logger.debug(
+                "Modified arrow key pressed: DOWN/J - Starting navigation (bypass deleted)"
+            )
+            self._navigate_down_sequential(skip_deleted=False)
+            return True
+        return False
+
     def eventFilter(self, obj: QObject, event: QEvent) -> bool:
         if event.type() == QEvent.Type.KeyPress:
             # Ensure the event is for one of our views
@@ -3384,68 +3416,24 @@ class MainWindow(QMainWindow):
                             self._handle_delete_action()
                             return True
 
-                    # --- Navigation with Ctrl modifier (bypasses deleted file skipping) ---
-                    elif modifiers == Qt.KeyboardModifier.ControlModifier:
-                        logger.debug(
-                            f"Ctrl+Arrow key detected: {key} - Navigation with deleted file bypass"
+                    # --- Navigation with Ctrl or Cmd modifier (bypasses deleted file skipping) ---
+                    elif modifiers in (
+                        Qt.KeyboardModifier.ControlModifier,
+                        Qt.KeyboardModifier.MetaModifier,
+                    ):
+                        mod_name = (
+                            "Ctrl"
+                            if modifiers == Qt.KeyboardModifier.ControlModifier
+                            else "Cmd"
                         )
-                        if key == Qt.Key.Key_Left or key == Qt.Key.Key_H:
-                            logger.debug(
-                                f"Ctrl+Arrow key pressed: LEFT/H - Starting navigation (bypass deleted)"
-                            )
-                            self._navigate_left_in_group(skip_deleted=False)
-                            return True
-                        if key == Qt.Key.Key_Right or key == Qt.Key.Key_L:
-                            logger.debug(
-                                f"Ctrl+Arrow key pressed: RIGHT/L - Starting navigation (bypass deleted)"
-                            )
-                            self._navigate_right_in_group(skip_deleted=False)
-                            return True
-                        if key == Qt.Key.Key_Up or key == Qt.Key.Key_K:
-                            logger.debug(
-                                f"Ctrl+Arrow key pressed: UP/K - Starting navigation (bypass deleted)"
-                            )
-                            self._navigate_up_sequential(skip_deleted=False)
-                            return True
-                        if key == Qt.Key.Key_Down or key == Qt.Key.Key_J:
-                            logger.debug(
-                                f"Ctrl+Arrow key pressed: DOWN/J - Starting navigation (bypass deleted)"
-                            )
-                            self._navigate_down_sequential(skip_deleted=False)
-                            return True
-
-                    # On Mac, Cmd key might be used instead of Ctrl for some operations
-                    elif modifiers == Qt.KeyboardModifier.MetaModifier:
                         logger.debug(
-                            f"Cmd+Arrow key detected (Mac): {key} - Navigation with deleted file bypass"
+                            f"{mod_name}+Arrow key detected: {key} - Navigation with deleted file bypass"
                         )
-                        if key == Qt.Key.Key_Left or key == Qt.Key.Key_H:
-                            logger.debug(
-                                f"Cmd+Arrow key pressed: LEFT/H - Starting navigation (bypass deleted)"
-                            )
-                            self._navigate_left_in_group(skip_deleted=False)
-                            return True
-                        if key == Qt.Key.Key_Right or key == Qt.Key.Key_L:
-                            logger.debug(
-                                f"Cmd+Arrow key pressed: RIGHT/L - Starting navigation (bypass deleted)"
-                            )
-                            self._navigate_right_in_group(skip_deleted=False)
-                            return True
-                        if key == Qt.Key.Key_Up or key == Qt.Key.Key_K:
-                            logger.debug(
-                                f"Cmd+Arrow key pressed: UP/K - Starting navigation (bypass deleted)"
-                            )
-                            self._navigate_up_sequential(skip_deleted=False)
-                            return True
-                        if key == Qt.Key.Key_Down or key == Qt.Key.Key_J:
-                            logger.debug(
-                                f"Cmd+Arrow key pressed: DOWN/J - Starting navigation (bypass deleted)"
-                            )
-                            self._navigate_down_sequential(skip_deleted=False)
+                        if self._handle_modified_arrow_key_navigation(key):
                             return True
                     else:
                         logger.debug(
-                            f"Key with modifiers detected: {key}, modifiers: {modifiers}"
+                            f"Key with other modifiers detected: {key}, modifiers: {modifiers}"
                         )
             else:
                 logger.debug(

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -3445,8 +3445,6 @@ class MainWindow(QMainWindow):
                             )
                             self._navigate_down_sequential(skip_deleted=False)
                             return True
-                        else:
-                            logger.debug(f"Cmd+Key detected but not handled: key={key}")
                     else:
                         logger.debug(
                             f"Key with modifiers detected: {key}, modifiers: {modifiers}"

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -3396,7 +3396,7 @@ class MainWindow(QMainWindow):
                             self._navigate_left_in_group(skip_deleted=False)
                             return True
                         if key == Qt.Key.Key_Right or key == Qt.Key.Key_L:
-                            logger.info(
+                            logger.debug(
                                 f"Ctrl+Arrow key pressed: RIGHT/L - Starting navigation (bypass deleted)"
                             )
                             self._navigate_right_in_group(skip_deleted=False)
@@ -3413,8 +3413,6 @@ class MainWindow(QMainWindow):
                             )
                             self._navigate_down_sequential(skip_deleted=False)
                             return True
-                        else:
-                            logger.debug(f"Ctrl+Key detected but not handled: key={key}")
 
                     # On Mac, Cmd key might be used instead of Ctrl for some operations
                     elif modifiers == Qt.KeyboardModifier.MetaModifier:
@@ -3440,7 +3438,7 @@ class MainWindow(QMainWindow):
                             self._navigate_up_sequential(skip_deleted=False)
                             return True
                         if key == Qt.Key.Key_Down or key == Qt.Key.Key_J:
-                            logger.info(
+                            logger.debug(
                                 f"Cmd+Arrow key pressed: DOWN/J - Starting navigation (bypass deleted)"
                             )
                             self._navigate_down_sequential(skip_deleted=False)


### PR DESCRIPTION
This pull request introduces enhancements to navigation functionality in the image viewer application, including support for Vim-style keybindings, improved handling of deleted files during navigation, and platform-specific adaptations for macOS. It also removes redundant code to simplify maintenance. Below are the key changes grouped by theme:

### Navigation Enhancements:
* Added Vim-style keybindings (`H`, `J`, `K`, `L`) for navigating images, alongside existing arrow keys. Navigation skips files marked for deletion by default but can include them using `Ctrl` (or `Cmd` on macOS) + arrow keys or Vim-style keys. These changes are documented in `README.md` and implemented in `eventFilter` in `src/ui/main_window.py`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R183-R193) [[2]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181R3302-R3328) [[3]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181L3393-R3398)

### macOS-Specific Adaptations:
* Introduced support for using the `Cmd` key as a modifier for navigation operations on macOS, ensuring consistency with platform conventions.

### Code Simplification:
* Removed the `_validate_and_select_image_candidate` method from `src/ui/main_window.py`, consolidating its functionality into other parts of the navigation logic to reduce redundancy.…s to skip or include deleted images