### PR TITLE
Refactor: Mark for deletion rework

### DIFF
--- a/src/core/app_settings.py
+++ b/src/core/app_settings.py
@@ -17,7 +17,6 @@ PREVIEW_CACHE_SIZE_GB_KEY = "Cache/PreviewCacheSizeGB"
 EXIF_CACHE_SIZE_MB_KEY = "Cache/ExifCacheSizeMB"  # For EXIF metadata cache
 ROTATION_CONFIRM_LOSSY_KEY = "UI/RotationConfirmLossy"  # Ask before lossy rotation
 AUTO_EDIT_PHOTOS_KEY = "UI/AutoEditPhotos"  # Key for auto edit photos setting
-MARK_FOR_DELETION_MODE_KEY = "UI/MarkForDeletionMode"  # Key for mark for deletion mode
 RECENT_FOLDERS_KEY = "UI/RecentFolders"  # Key for recent folders list
 ORIENTATION_MODEL_NAME_KEY = (
     "Models/OrientationModelName"  # Key for the orientation model file name
@@ -28,7 +27,6 @@ DEFAULT_PREVIEW_CACHE_SIZE_GB = 2.0  # Default to 2 GB for preview cache
 DEFAULT_EXIF_CACHE_SIZE_MB = 256  # Default to 256 MB for EXIF cache
 DEFAULT_ROTATION_CONFIRM_LOSSY = True  # Default to asking before lossy rotation
 DEFAULT_AUTO_EDIT_PHOTOS = False  # Default auto edit photos setting
-DEFAULT_MARK_FOR_DELETION_MODE = True  # Default mark for deletion mode setting
 MAX_RECENT_FOLDERS = 10  # Max number of recent folders to store
 DEFAULT_ORIENTATION_MODEL_NAME = None  # Default to None, so we can auto-detect
 
@@ -180,21 +178,6 @@ def set_auto_edit_photos(enabled: bool):
     """Set whether auto edit photos is enabled."""
     settings = _get_settings()
     settings.setValue(AUTO_EDIT_PHOTOS_KEY, enabled)
-
-
-# --- Mark for Deletion Mode Setting ---
-def get_mark_for_deletion_mode() -> bool:
-    """Get whether mark for deletion mode is enabled."""
-    settings = _get_settings()
-    return settings.value(
-        MARK_FOR_DELETION_MODE_KEY, DEFAULT_MARK_FOR_DELETION_MODE, type=bool
-    )
-
-
-def set_mark_for_deletion_mode(enabled: bool):
-    """Set whether mark for deletion mode is enabled."""
-    settings = _get_settings()
-    settings.setValue(MARK_FOR_DELETION_MODE_KEY, enabled)
 
 
 # --- Recent Folders ---

--- a/src/ui/app_state.py
+++ b/src/ui/app_state.py
@@ -29,6 +29,7 @@ class AppState:
             RatingCache()
         )  # Instance of the new disk cache for ratings
         self.exif_disk_cache = ExifCache()  # Instance of the new disk cache for EXIF data, now reads size from app_settings
+        self.marked_for_deletion: set = set()  # Set of file paths marked for deletion
 
         # Could also hold current folder path, filter states, etc. if desired.
         self.current_folder_path: Optional[str] = None
@@ -43,6 +44,7 @@ class AppState:
         self.date_cache.clear()
         self.cluster_results.clear()
         self.embeddings_cache.clear()
+        self.marked_for_deletion.clear()  # Clear marked for deletion set
         if self.rating_disk_cache:
             self.rating_disk_cache.clear()  # Decide if folder clear should wipe the whole disk cache
         if self.exif_disk_cache:
@@ -115,3 +117,23 @@ class AppState:
             if file_data.get("path") == file_path:
                 return file_data
         return None
+
+    def mark_for_deletion(self, file_path: str):
+        """Marks a file for deletion."""
+        self.marked_for_deletion.add(file_path)
+
+    def unmark_for_deletion(self, file_path: str):
+        """Unmarks a file for deletion."""
+        self.marked_for_deletion.discard(file_path)
+
+    def is_marked_for_deletion(self, file_path: str) -> bool:
+        """Checks if a file is marked for deletion."""
+        return file_path in self.marked_for_deletion
+
+    def get_marked_files(self) -> List[str]:
+        """Returns a list of all files marked for deletion."""
+        return list(self.marked_for_deletion)
+
+    def clear_all_deletion_marks(self):
+        """Clears all deletion marks."""
+        self.marked_for_deletion.clear()

--- a/src/ui/menu_manager.py
+++ b/src/ui/menu_manager.py
@@ -45,7 +45,6 @@ class MenuManager:
         # Settings Menu
         self.manage_cache_action: QAction
         self.toggle_auto_edits_action: QAction
-        self.toggle_mark_for_deletion_action: QAction
 
         # Image Menu
         self.rotate_clockwise_action: QAction
@@ -330,19 +329,6 @@ class MenuManager:
         self.toggle_auto_edits_action.setShortcut(QKeySequence("F10"))
         settings_menu.addAction(self.toggle_auto_edits_action)
 
-        self.toggle_mark_for_deletion_action = QAction(
-            "Mark for Deletion (vs. Direct Delete)", main_win
-        )
-        self.toggle_mark_for_deletion_action.setCheckable(True)
-        self.toggle_mark_for_deletion_action.setChecked(
-            main_win.mark_for_deletion_mode_enabled
-        )
-        self.toggle_mark_for_deletion_action.setToolTip(
-            "If checked, the Delete key will mark files for later deletion. If unchecked, it will move them to trash immediately."
-        )
-        self.toggle_mark_for_deletion_action.setShortcut(QKeySequence("F11"))
-        settings_menu.addAction(self.toggle_mark_for_deletion_action)
-
     def _create_help_menu(self, menu_bar):
         help_menu = menu_bar.addMenu("&Help")
         help_menu.addAction(self.about_action)
@@ -382,9 +368,6 @@ class MenuManager:
         )
         self.toggle_auto_edits_action.toggled.connect(
             main_win._handle_toggle_auto_edits
-        )
-        self.toggle_mark_for_deletion_action.toggled.connect(
-            main_win._handle_toggle_mark_for_deletion_mode
         )
 
         # Image Menu


### PR DESCRIPTION
This pull request introduces significant changes to the handling of file deletion marks in the application. The changes remove the "Mark for Deletion Mode" setting from the app settings and replace it with a more flexible, per-file deletion marking system. This approach simplifies the user interface and improves the functionality by allowing users to toggle deletion marks directly on files without relying on a global mode.

### Removal of "Mark for Deletion Mode" Setting:
- [`src/core/app_settings.py`](diffhunk://#diff-7692944c2605b0f9876367f27fc7fb7c1bb2ac313c01d08b3f787e68208a5492L20): Removed the `MARK_FOR_DELETION_MODE_KEY` and its associated default value, getter, and setter methods. This eliminates the global setting for marking files for deletion. [[1]](diffhunk://#diff-7692944c2605b0f9876367f27fc7fb7c1bb2ac313c01d08b3f787e68208a5492L20) [[2]](diffhunk://#diff-7692944c2605b0f9876367f27fc7fb7c1bb2ac313c01d08b3f787e68208a5492L31) [[3]](diffhunk://#diff-7692944c2605b0f9876367f27fc7fb7c1bb2ac313c01d08b3f787e68208a5492L185-L199)
- [`src/ui/main_window.py`](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181L64-L65): Removed references to the "Mark for Deletion Mode" setting, including its initialization, toggle handler, and related status messages. [[1]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181L64-L65) [[2]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181L196) [[3]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181L3073-L3082)

### Introduction of Per-File Deletion Marking:
- [`src/ui/app_state.py`](diffhunk://#diff-e31ca1bdceee777d6d05ea56e63b54447925539d7f7500e2c3196a1919dcfa55R32): Added a `marked_for_deletion` set and methods to manage deletion marks on individual files (`mark_for_deletion`, `unmark_for_deletion`, `is_marked_for_deletion`, `get_marked_files`, `clear_all_deletion_marks`). These methods enable fine-grained control over file deletion marks. [[1]](diffhunk://#diff-e31ca1bdceee777d6d05ea56e63b54447925539d7f7500e2c3196a1919dcfa55R32) [[2]](diffhunk://#diff-e31ca1bdceee777d6d05ea56e63b54447925539d7f7500e2c3196a1919dcfa55R47) [[3]](diffhunk://#diff-e31ca1bdceee777d6d05ea56e63b54447925539d7f7500e2c3196a1919dcfa55R120-R139)
- [`src/ui/main_window.py`](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181L2762-R2760): Updated file marking logic to use the new `app_state` methods. Files are now marked for deletion without renaming, and the UI reflects the marked status with a "(DELETED)" suffix. [[1]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181L2762-R2760) [[2]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181L3920-R3910) [[3]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181L3933-R3920) [[4]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181L4014-R3997) [[5]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181L4126-R4176) [[6]](diffhunk://#diff-0729192efcb23689752beadd7d38502a383d42f1bbdc3ef9e81da48bc6e7c181L4354-R4337)

### Simplification of UI Components:
- [`src/ui/menu_manager.py`](diffhunk://#diff-6a69d14f37dcc5fdfee5f21035dbbd3e8a688bda477cac0d6ef08901383d513aL48): Removed the "Mark for Deletion Mode" toggle action from the settings menu, as the functionality is now handled per file. [[1]](diffhunk://#diff-6a69d14f37dcc5fdfee5f21035dbbd3e8a688bda477cac0d6ef08901383d513aL48) [[2]](diffhunk://#diff-6a69d14f37dcc5fdfee5f21035dbbd3e8a688bda477cac0d6ef08901383d513aL333-L345) [[3]](diffhunk://#diff-6a69d14f37dcc5fdfee5f21035dbbd3e8a688bda477cac0d6ef08901383d513aL386-L388)

These changes streamline the deletion marking process, making it more intuitive for users and reducing the complexity of the codebase.…. Remove mark for deletion functionality from app settings and UI components - to mark an image to delete just press d