### PR TITLE
Update default OpenAI model in release notes script

### DIFF
--- a/.github/scripts/generate_release_notes.py
+++ b/.github/scripts/generate_release_notes.py
@@ -30,7 +30,7 @@ class ReleaseNotesGenerator:
         # The OpenAI client reads org/project from env if present
         self.client = OpenAI(api_key=api_key)
         # Allow override via env OPENAI_MODEL; default to a cost-effective model
-        self.model = model or os.getenv("OPENAI_MODEL", "gpt-5-nano-2025-08-07")
+        self.model = model or os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 
     @staticmethod
     def _sanitize_notes(text: str, repo_url: Optional[str]) -> str:


### PR DESCRIPTION
This pull request updates the default OpenAI model used in the `generate_release_notes.py` script to ensure more predictable and cost-effective behavior.

Model configuration update:

* Changed the default model in the `ReleaseNotesGenerator` class from `"gpt-5-nano-2025-08-07"` to `"gpt-4o-mini"`, unless overridden by the `OPENAI_MODEL` environment variable.