### PR TITLE
Fix: Insert hidden import pyexiv2 first in PyInstaller build

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -111,11 +111,11 @@ jobs:
             --paths src `
             --add-data "src/ui/dark_theme.qss;." `
             --add-data "assets/app_icon.ico;." `
+            --hidden-import pyexiv2 `
             --hidden-import PyQt6.QtCore `
             --hidden-import PyQt6.QtGui `
             --hidden-import PyQt6.QtWidgets `
             --hidden-import rawpy `
-            --hidden-import pyexiv2 `
             --hidden-import cv2 `
             --hidden-import onnxruntime `
             --hidden-import torchvision `


### PR DESCRIPTION
This pull request makes a minor adjustment to the build configuration in `.github/workflows/release-build.yml`. The change reorders the inclusion of the `pyexiv2` module in the list of hidden imports for the build process in attempt to fix Windows pyexiv2 crash