### PR TITLE
Enhance pyexiv2 initialization: centralize and ensure safe loading be…

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -111,11 +111,11 @@ jobs:
             --paths src `
             --add-data "src/ui/dark_theme.qss;." `
             --add-data "assets/app_icon.ico;." `
+            --hidden-import pyexiv2 `
             --hidden-import PyQt6.QtCore `
             --hidden-import PyQt6.QtGui `
             --hidden-import PyQt6.QtWidgets `
             --hidden-import rawpy `
-            --hidden-import pyexiv2 `
             --hidden-import cv2 `
             --hidden-import onnxruntime `
             --hidden-import torchvision `
@@ -123,6 +123,7 @@ jobs:
             --hidden-import sklearn `
             --hidden-import sentence_transformers `
             --add-data "models;models" `
+            --runtime-hook runtime_hook.py `
             src/main.py
 
       - name: Collect artifact (Windows .exe)

--- a/runtime_hook.py
+++ b/runtime_hook.py
@@ -1,0 +1,37 @@
+"""
+PyInstaller runtime hook to ensure pyexiv2 is loaded before Qt libraries.
+
+This hook ensures that pyexiv2 is imported before any Qt/PyQt libraries
+to prevent DLL conflicts on Windows.
+"""
+
+import sys
+
+# Import pyexiv2 first to prevent Qt conflicts
+try:
+    import pyexiv2  # noqa: F401
+    
+    # Force initialization of pyexiv2 library to load all DLLs
+    try:
+        # Try to create a dummy image to fully initialize the library
+        test_path = "non_existent_file_for_init.jpg"
+        try:
+            with pyexiv2.Image(test_path):
+                pass
+        except (FileNotFoundError, OSError, RuntimeError):
+            # Expected - we just want to trigger initialization
+            pass
+    except Exception:
+        # Initialization may fail, but that's okay as long as pyexiv2 is imported
+        pass
+        
+except ImportError:
+    # If pyexiv2 is not available, log but don't fail
+    print("Warning: pyexiv2 not available in runtime hook")
+
+# Check if any Qt modules are already loaded
+qt_modules = [name for name in sys.modules.keys() if name.startswith(('PyQt', 'PySide', 'Qt'))]
+if qt_modules:
+    print(f"Warning: Qt modules detected before pyexiv2 initialization: {qt_modules}")
+else:
+    print("Runtime hook: pyexiv2 loaded before Qt modules")

--- a/src/core/image_processing/image_rotator.py
+++ b/src/core/image_processing/image_rotator.py
@@ -4,7 +4,12 @@ import subprocess
 import tempfile
 from typing import Literal, Tuple
 from PIL import Image, ImageOps
+
+# Ensure pyexiv2 is properly initialized before use
+from core.pyexiv2_init import ensure_pyexiv2_initialized
+ensure_pyexiv2_initialized()
 import pyexiv2
+
 from pathlib import Path
 from core.image_file_ops import ImageFileOperations
 from core.app_settings import JPEGTRAN_TIMEOUT_SECONDS

--- a/src/core/metadata_io.py
+++ b/src/core/metadata_io.py
@@ -1,0 +1,458 @@
+# Centralized pyexiv2 usage. Tests and main app ensure early import of pyexiv2
+# where necessary to avoid Windows issues; importing here is acceptable.
+from core.pyexiv2_init import ensure_pyexiv2_initialized
+ensure_pyexiv2_initialized()
+import pyexiv2
+
+import os
+import sys
+import threading
+import logging
+import queue
+from typing import Dict, Optional, Tuple, Callable, Any
+
+logger = logging.getLogger(__name__)
+
+
+class MetadataIO:
+    """Thin, threadsafe facade around pyexiv2 operations.
+
+    Responsibilities:
+    - Open images safely with a global lock (pyexiv2/thread/frozen stability)
+    - Read merged EXIF/IPTC/XMP along with basic properties
+    - Read/Write specific tags (rating, orientation)
+    - Provide small utility reads (orientation + dimensions)
+
+    All methods expect an operational filesystem path (existing file path).
+    Path normalization/resolution is intentionally kept in higher layers.
+    """
+
+    _LOCK = threading.Lock()
+    _WARMED_UP = False
+    _FIRST_REAL_ACCESS_LOGGED = False
+    # Legacy flags kept for compatibility; real access is now bound to a dedicated worker thread
+    _FIRST_ACCESS_DONE = False
+    _FIRST_ACCESS_EVENT = threading.Event()
+
+    # Single-thread dispatcher to avoid cross-thread usage of pyexiv2 (not thread-safe)
+    _TASK_QUEUE: Optional["queue.Queue[tuple]"] = None
+    _WORKER_THREAD: Optional[threading.Thread] = None
+    _WORKER_READY_EVENT = threading.Event()
+    _STOP_EVENT = threading.Event()
+    _THREAD_NAME = "pyexiv2-io"
+
+    @classmethod
+    def _should_use_worker_thread(cls) -> bool:
+        """Use the dedicated single thread on Windows or in frozen builds (safest).
+
+        Can be forced via PHOTOSORT_FORCE_PYEXIV2_THREAD=true.
+        """
+        try:
+            force = os.environ.get(
+                "PHOTOSORT_FORCE_PYEXIV2_THREAD", "false"
+            ).lower() in {"1", "true", "yes"}
+        except Exception:
+            force = False
+        return force or sys.platform.startswith("win") or getattr(sys, "frozen", False)
+
+    @classmethod
+    def start_worker_thread(cls) -> None:
+        """Start the dedicated pyexiv2 IO thread (idempotent)."""
+        if not cls._should_use_worker_thread():
+            return
+        with cls._LOCK:
+            if cls._WORKER_THREAD and cls._WORKER_THREAD.is_alive():
+                return
+            cls._TASK_QUEUE = queue.Queue()
+            cls._STOP_EVENT.clear()
+            cls._WORKER_READY_EVENT.clear()
+
+            def _worker_loop():
+                logger.info("MetadataIO worker thread starting...")
+                # Perform thread-local initialization and a benign first Image open within this thread
+                try:
+                    temp_path = None
+                    try:
+                        temp_path = cls._make_temp_jpeg_path()
+                        try:
+                            with pyexiv2.Image(temp_path, encoding="utf-8"):
+                                pass
+                        except Exception as e_open:
+                            logger.debug(
+                                f"Worker warmup open failed (continuing): {e_open}"
+                            )
+                    finally:
+                        if temp_path and os.path.exists(temp_path):
+                            try:
+                                os.remove(temp_path)
+                            except Exception:
+                                pass
+                finally:
+                    # Signal that the worker is ready to accept tasks
+                    try:
+                        cls._WORKER_READY_EVENT.set()
+                    except Exception:
+                        pass
+
+                # Main task processing loop
+                try:
+                    while not cls._STOP_EVENT.is_set():
+                        try:
+                            item = cls._TASK_QUEUE.get(timeout=0.2)  # type: ignore[arg-type]
+                        except queue.Empty:
+                            continue
+                        if item is None:
+                            break
+                        fn, args, kwargs, reply_q = item
+                        try:
+                            result = fn(*args, **kwargs)
+                            reply_q.put((True, result))
+                        except Exception as e:
+                            reply_q.put((False, e))
+                        finally:
+                            try:
+                                cls._TASK_QUEUE.task_done()  # type: ignore[union-attr]
+                            except Exception:
+                                pass
+                except Exception as loop_err:
+                    logger.error(
+                        f"MetadataIO worker loop error: {loop_err}", exc_info=True
+                    )
+                finally:
+                    logger.info("MetadataIO worker thread exiting.")
+
+            t = threading.Thread(
+                target=_worker_loop, name=cls._THREAD_NAME, daemon=True
+            )
+            t.start()
+            cls._WORKER_THREAD = t
+        # Wait briefly for readiness
+        try:
+            cls._WORKER_READY_EVENT.wait(timeout=3.0)
+        except Exception:
+            pass
+
+    @classmethod
+    def _call_in_worker(cls, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Dispatch a callable to the dedicated worker and wait for result."""
+        if not cls._should_use_worker_thread():
+            # Fallback to direct call (non-Windows, non-frozen dev runs)
+            return fn(*args, **kwargs)
+        # If we're already on the worker thread, execute directly to avoid deadlock
+        try:
+            if threading.current_thread().name == cls._THREAD_NAME:
+                return fn(*args, **kwargs)
+        except Exception:
+            pass
+        cls.start_worker_thread()
+        if not cls._TASK_QUEUE:
+            raise RuntimeError("MetadataIO worker queue not initialized")
+        reply_q: "queue.Queue[tuple]" = queue.Queue(maxsize=1)
+        cls._TASK_QUEUE.put((fn, args, kwargs, reply_q))
+        ok, payload = reply_q.get()
+        if ok:
+            return payload
+        raise payload
+
+    @staticmethod
+    def _make_temp_jpeg_path() -> str:
+        """Create a writable temp JPEG path with a closed handle (Windows-safe).
+
+        Returns a path to a tiny valid JPEG. Caller must delete the file.
+        """
+        import tempfile
+        from PIL import Image
+
+        def _try_in_dir(base_dir: Optional[str]) -> Optional[str]:
+            try:
+                if base_dir:
+                    os.makedirs(base_dir, exist_ok=True)
+                fd, path = tempfile.mkstemp(suffix=".jpg", dir=base_dir)
+                try:
+                    os.close(fd)  # close handle to allow other opens on Windows
+                except Exception:
+                    pass
+                # Write a tiny JPEG
+                img = Image.new("RGB", (2, 2), color=(0, 0, 0))
+                img.save(path, format="JPEG")
+                return path
+            except Exception:
+                return None
+
+        # Try default temp dir
+        p = _try_in_dir(None)
+        if p:
+            return p
+        # Fallback to user cache dir
+        fallback_dir = os.path.join(os.path.expanduser("~"), ".photosort_cache")
+        p = _try_in_dir(fallback_dir)
+        if p:
+            return p
+        # Last resort: current working directory
+        p = _try_in_dir(os.getcwd())
+        if p:
+            return p
+        raise PermissionError("Failed to create a temporary JPEG file for warmup")
+
+    @classmethod
+    def warmup(cls) -> None:
+        """Perform a one-time light initialization (import/logging).
+
+        Do NOT open any real Image() here; all real access will be executed on
+        the dedicated worker thread to avoid cross-thread issues.
+        """
+        if cls._WARMED_UP:
+            return
+        with cls._LOCK:
+            if cls._WARMED_UP:
+                return
+            # Nothing heavy to do here; keep for symmetry and future-proofing
+            cls._WARMED_UP = True
+            logger.info("MetadataIO warmup flag set (no Image open).")
+
+    @classmethod
+    def ensure_first_access_main_thread(cls) -> None:
+        """Deprecated: real access now happens on a dedicated worker thread.
+
+        Kept as a no-op to avoid call-site crashes in older code paths.
+        """
+        with cls._LOCK:
+            if not cls._FIRST_ACCESS_DONE:
+                cls._FIRST_ACCESS_DONE = True
+                try:
+                    cls._FIRST_ACCESS_EVENT.set()
+                except Exception:
+                    pass
+                logger.info(
+                    "MetadataIO main-thread first access skipped (using worker thread)."
+                )
+
+    @classmethod
+    def _read_raw_metadata_inner(cls, operational_path: str) -> Dict:
+        """Return a merged metadata dict for the given image path.
+
+        The dict includes at least:
+        - file_path, pixel_width, pixel_height, mime_type, file_size
+        - merged EXIF/IPTC/XMP dictionaries (keys in their native pyexiv2 form)
+        On error, returns a dict with 'file_path', 'file_size' and an 'error' string.
+        """
+        if not os.path.isfile(operational_path):
+            return {
+                "file_path": operational_path,
+                "file_size": "Unknown",
+                "error": "File missing at extraction time",
+            }
+        try:
+            if not cls._FIRST_REAL_ACCESS_LOGGED:
+                import threading as _th
+
+                logger.info(
+                    "MetadataIO first real pyexiv2 access (warmed_up=%s, thread=%s)",
+                    cls._WARMED_UP,
+                    _th.current_thread().name,
+                )
+                cls._FIRST_REAL_ACCESS_LOGGED = True
+            with pyexiv2.Image(operational_path, encoding="utf-8") as img:
+                md = {
+                    "file_path": operational_path,
+                    "pixel_width": img.get_pixel_width(),
+                    "pixel_height": img.get_pixel_height(),
+                    "mime_type": img.get_mime_type(),
+                    "file_size": os.path.getsize(operational_path)
+                    if os.path.isfile(operational_path)
+                    else "Unknown",
+                }
+                try:
+                    exif = img.read_exif() or {}
+                    if exif:
+                        md.update(exif)
+                except Exception:
+                    logger.debug(f"No EXIF for {os.path.basename(operational_path)}")
+                try:
+                    iptc = img.read_iptc() or {}
+                    if iptc:
+                        md.update(iptc)
+                except Exception:
+                    logger.debug(f"No IPTC for {os.path.basename(operational_path)}")
+                try:
+                    xmp = img.read_xmp() or {}
+                    if xmp:
+                        md.update(xmp)
+                except Exception:
+                    logger.debug(f"No XMP for {os.path.basename(operational_path)}")
+                return md
+        except Exception as e:
+            msg = str(e)
+            is_missing = (
+                ("No such file or directory" in msg)
+                or ("errno = 2" in msg)
+                or (not os.path.isfile(operational_path))
+            )
+            level = logger.warning if is_missing else logger.error
+            level(
+                f"Error extracting metadata for {os.path.basename(operational_path)}: {e}",
+                exc_info=not is_missing,
+            )
+            return {
+                "file_path": operational_path,
+                "file_size": os.path.getsize(operational_path)
+                if os.path.isfile(operational_path)
+                else "Unknown",
+                "error": f"Extraction failed: {e}",
+            }
+
+    @classmethod
+    def read_raw_metadata(cls, operational_path: str) -> Dict:
+        """Public API: dispatch to the dedicated worker thread when enabled."""
+        return cls._call_in_worker(cls._read_raw_metadata_inner, operational_path)
+
+    @classmethod
+    def _set_xmp_rating_inner(cls, operational_path: str, rating: int) -> bool:
+        """Set XMP rating (0-5). Returns True if succeeded."""
+        if not os.path.isfile(operational_path):
+            logger.warning(f"Cannot set rating; file missing: {operational_path}")
+            return False
+        try:
+            with pyexiv2.Image(operational_path, encoding="utf-8") as img:
+                img.modify_xmp({"Xmp.xmp.Rating": str(int(rating))})
+                return True
+        except Exception as e:
+            logger.error(
+                f"Error setting rating for {os.path.basename(operational_path)}: {e}",
+                exc_info=True,
+            )
+            return False
+
+    @classmethod
+    def set_xmp_rating(cls, operational_path: str, rating: int) -> bool:
+        return cls._call_in_worker(cls._set_xmp_rating_inner, operational_path, rating)
+
+    @classmethod
+    def _read_exif_orientation_inner(cls, operational_path: str) -> Optional[int]:
+        """Read EXIF orientation value if present (1-8)."""
+        if not os.path.isfile(operational_path):
+            logger.info(
+                f"File missing when querying EXIF orientation: {operational_path}"
+            )
+            return None
+        try:
+            with pyexiv2.Image(operational_path, encoding="utf-8") as img:
+                exif = img.read_exif() or {}
+                val = exif.get("Exif.Image.Orientation")
+                return int(val) if val is not None else None
+        except Exception as e:
+            msg = str(e)
+            if (
+                ("No such file or directory" in msg)
+                or ("errno = 2" in msg)
+                or (not os.path.isfile(operational_path))
+            ):
+                logger.warning(
+                    f"File missing while reading EXIF orientation: {operational_path} ({msg})"
+                )
+            else:
+                logger.error(
+                    f"Error getting EXIF orientation for {os.path.basename(operational_path)}: {e}",
+                    exc_info=True,
+                )
+            return None
+
+    @classmethod
+    def read_exif_orientation(cls, operational_path: str) -> Optional[int]:
+        return cls._call_in_worker(cls._read_exif_orientation_inner, operational_path)
+
+    @classmethod
+    def _set_exif_orientation_inner(
+        cls, operational_path: str, orientation: int
+    ) -> bool:
+        """Write EXIF orientation (1-8). Returns True if succeeded."""
+        if not os.path.isfile(operational_path):
+            logger.warning(
+                f"Cannot set EXIF orientation; file missing: {operational_path}"
+            )
+            return False
+        try:
+            with pyexiv2.Image(operational_path, encoding="utf-8") as img:
+                img.modify_exif({"Exif.Image.Orientation": int(orientation)})
+                return True
+        except Exception as e:
+            logger.error(
+                f"Error setting EXIF orientation for {os.path.basename(operational_path)}: {e}",
+                exc_info=True,
+            )
+            return False
+
+    @classmethod
+    def set_exif_orientation(cls, operational_path: str, orientation: int) -> bool:
+        return cls._call_in_worker(
+            cls._set_exif_orientation_inner, operational_path, orientation
+        )
+
+    @classmethod
+    def _set_xmp_orientation_inner(
+        cls, operational_path: str, orientation: int
+    ) -> bool:
+        """Attempt to set XMP tiff Orientation. Returns True if succeeded."""
+        if not os.path.isfile(operational_path):
+            logger.warning(
+                f"Cannot set XMP orientation; file missing: {operational_path}"
+            )
+            return False
+        try:
+            with pyexiv2.Image(operational_path, encoding="utf-8") as img:
+                img.modify_xmp({"Xmp.tiff.Orientation": str(int(orientation))})
+                return True
+        except Exception as e:
+            logger.debug(
+                f"Could not set XMP orientation for {os.path.basename(operational_path)}: {e}"
+            )
+            return False
+
+    @classmethod
+    def set_xmp_orientation(cls, operational_path: str, orientation: int) -> bool:
+        return cls._call_in_worker(
+            cls._set_xmp_orientation_inner, operational_path, orientation
+        )
+
+    @classmethod
+    def _read_orientation_and_dimensions_inner(
+        cls, operational_path: str
+    ) -> Tuple[Optional[int], Optional[int], Optional[int]]:
+        """Efficiently read orientation, pixel width, and pixel height."""
+        if not os.path.isfile(operational_path):
+            logger.info(
+                f"File missing when reading orientation/dimensions: {operational_path}"
+            )
+            return None, None, None
+        try:
+            with pyexiv2.Image(operational_path, encoding="utf-8") as img:
+                exif = img.read_exif() or {}
+                orientation = exif.get("Exif.Image.Orientation")
+                orientation_val = int(orientation) if orientation else None
+                width = img.get_pixel_width()
+                height = img.get_pixel_height()
+                return orientation_val, width, height
+        except Exception as e:
+            msg = str(e)
+            if (
+                ("No such file or directory" in msg)
+                or ("errno = 2" in msg)
+                or (not os.path.isfile(operational_path))
+            ):
+                logger.warning(
+                    f"File missing while reading orientation/dimensions: {operational_path} ({msg})"
+                )
+            else:
+                logger.error(
+                    f"Error getting orientation/dimensions for {os.path.basename(operational_path)}: {e}",
+                    exc_info=True,
+                )
+            return None, None, None
+
+    @classmethod
+    def read_orientation_and_dimensions(
+        cls, operational_path: str
+    ) -> Tuple[Optional[int], Optional[int], Optional[int]]:
+        return cls._call_in_worker(
+            cls._read_orientation_and_dimensions_inner, operational_path
+        )

--- a/src/core/pyexiv2_init.py
+++ b/src/core/pyexiv2_init.py
@@ -1,0 +1,72 @@
+"""
+PyExiv2 initialization module.
+
+This module must be imported before any Qt/PyQt imports to avoid DLL conflicts
+on Windows. PyExiv2 has a known issue where it must be imported before Qt
+libraries to prevent access violations.
+
+This module should be imported at the very beginning of the application.
+"""
+
+import sys
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+# Global flag to track if pyexiv2 has been safely initialized
+_PYEXIV2_INITIALIZED = False
+_INIT_LOCK = threading.Lock()
+
+
+def ensure_pyexiv2_initialized():
+    """
+    Ensure pyexiv2 is safely initialized before any Qt imports.
+    This function is idempotent and safe to call multiple times.
+    """
+    global _PYEXIV2_INITIALIZED
+    
+    with _INIT_LOCK:
+        if _PYEXIV2_INITIALIZED:
+            return
+        
+        try:
+            # Check if any Qt modules have already been imported
+            qt_modules = [
+                name for name in sys.modules.keys() 
+                if name.startswith(('PyQt', 'PySide', 'Qt'))
+            ]
+            
+            if qt_modules:
+                logger.warning(
+                    f"Qt modules already imported before pyexiv2 initialization: {qt_modules}. "
+                    "This may cause DLL conflicts on Windows."
+                )
+            
+            # Import pyexiv2 to ensure it's loaded first
+            import pyexiv2  # noqa: F401
+            
+            # Try to create a dummy image to fully initialize the library
+            # This ensures all DLLs are loaded before any Qt operations
+            try:
+                # Test with a non-existent file to trigger initialization without side effects
+                test_path = "non_existent_file_for_init.jpg"
+                try:
+                    with pyexiv2.Image(test_path):
+                        pass
+                except (FileNotFoundError, OSError, RuntimeError):
+                    # Expected - we just want to trigger initialization
+                    pass
+            except Exception as init_error:
+                logger.debug(f"Pyexiv2 initialization test failed (this is expected): {init_error}")
+            
+            _PYEXIV2_INITIALIZED = True
+            logger.debug("pyexiv2 successfully initialized before Qt imports")
+            
+        except Exception as e:
+            logger.error(f"Failed to initialize pyexiv2: {e}")
+            raise
+
+
+# Initialize immediately when this module is imported
+ensure_pyexiv2_initialized()

--- a/src/core/rating_loader_worker.py
+++ b/src/core/rating_loader_worker.py
@@ -4,6 +4,10 @@ import logging
 from PyQt6.QtCore import QObject, pyqtSignal
 from typing import List, Dict, Any, Optional
 
+# Ensure pyexiv2 is properly initialized before any metadata operations
+from core.pyexiv2_init import ensure_pyexiv2_initialized
+ensure_pyexiv2_initialized()
+
 from core.metadata_processor import MetadataProcessor
 from core.caching.rating_cache import RatingCache
 from core.app_settings import METADATA_EMIT_BATCH_SIZE

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,21 @@
-import pyexiv2  # noqa: F401  # This must be the first import or else it will cause a silent crash on windows
+# CRITICAL: Import pyexiv2 initialization BEFORE any other imports
+# This prevents DLL conflicts with Qt libraries on Windows
 import sys
 import os
+
+# Ensure the 'src' directory is on sys.path before any other imports
+SRC_DIR = os.path.dirname(__file__)
+if SRC_DIR and SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+# Initialize pyexiv2 before any Qt imports - this is CRITICAL for Windows stability
+try:
+    from core.pyexiv2_init import ensure_pyexiv2_initialized  # noqa: E402
+    ensure_pyexiv2_initialized()
+except Exception as e:
+    # If we can't initialize pyexiv2, log the error but don't prevent app startup
+    print(f"Warning: Failed to initialize pyexiv2: {e}")
+    
 import logging
 import time
 import argparse


### PR DESCRIPTION
…fore Qt imports to prevent DLL conflicts on Windows

This pull request introduces a robust solution to prevent DLL conflicts between `pyexiv2` and Qt libraries on Windows by enforcing early and safe initialization of `pyexiv2` throughout the codebase. The changes include a dedicated initialization module, integration of this initialization in all relevant entry points and worker threads, and a PyInstaller runtime hook to guarantee the correct import order in packaged builds.

**PyExiv2 Initialization and Import Order (Windows DLL Conflict Prevention):**

* Added a new module `core/pyexiv2_init.py` that provides an `ensure_pyexiv2_initialized()` function to safely initialize `pyexiv2` before any Qt imports, including checks and logging for import order issues. This function is now called at the start of the application and in all relevant modules.
* Updated `src/main.py` to call `ensure_pyexiv2_initialized()` before any other imports, ensuring `pyexiv2` is loaded before Qt libraries, which is critical for Windows stability.
* Integrated calls to `ensure_pyexiv2_initialized()` at the top of `image_rotator.py`, `metadata_processor.py`, and `rating_loader_worker.py` to guarantee proper initialization in all metadata-related operations. [[1]](diffhunk://#diff-0f3bda4f81336fd3296a11d23be713314ac29ed2f2c038a3a5844ca9a209ed78R7-R12) [[2]](diffhunk://#diff-d828d6aae2d520306af2f3532c467286cecbcadb18a6c871ef37286edd07fd53R1-R5) [[3]](diffhunk://#diff-809d5f3dcc24492c2bc7d24f18c4952b35a164a0fef9a9ab38939c72f02782d6R7-R10)

**Thread Safety and Worker Initialization:**

* In `metadata_processor.py`, added logic to initialize `pyexiv2` in every worker thread of the `ThreadPoolExecutor` via a new `worker_initializer` function, and ensured initialization within each chunk-processing thread for maximum safety. [[1]](diffhunk://#diff-d828d6aae2d520306af2f3532c467286cecbcadb18a6c871ef37286edd07fd53R316-R323) [[2]](diffhunk://#diff-d828d6aae2d520306af2f3532c467286cecbcadb18a6c871ef37286edd07fd53R341-R343) [[3]](diffhunk://#diff-d828d6aae2d520306af2f3532c467286cecbcadb18a6c871ef37286edd07fd53L417-R432)

**PyInstaller Build Process:**

* Added a custom PyInstaller runtime hook (`runtime_hook.py`) that imports and initializes `pyexiv2` before any Qt modules at runtime, with checks and warnings for incorrect import order, preventing DLL conflicts in the packaged Windows executable. The hook is now referenced in the build workflow. [[1]](diffhunk://#diff-7a4941dcb97b3b662f850c0ac874d34327ee1661975f6b63399c2132105789caR1-R37) [[2]](diffhunk://#diff-52120b4145bd2cf9c735193f6a093a7944688b21f04e854447e34a5049fc829fR114-R126)