### PR TITLE
refactor: Remove jpegtran dependency and update ImageRotator for metadata-first rotation approach 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,6 @@ PhotoSort is a powerful desktop application focused on speed designed to streaml
 
 ## Getting Started
 
-### Prerequisites
-
-* **Python 3.x**: Download from [python.org](https://www.python.org/).
-* **jpegtran (Optional, for Lossless JPEG Rotation)**:
-  * **Windows**: Download from [jpegclub.org](http://jpegclub.org/jpegtran/) or install via Chocolatey: `choco install libjpeg-turbo`
-  * **macOS**: `brew install jpeg-turbo`
-  * **Linux**: `sudo apt-get install libjpeg-turbo-progs` (Ubuntu/Debian) or `sudo yum install libjpeg-turbo-utils` (RedHat/CentOS)
-
 ### Hardware Acceleration (Optional, Recommended)
 
 For significantly faster AI-powered features like **Rotation Detection** and **Similarity Analysis**, use the appropriate requirements file for your hardware.

--- a/src/core/app_settings.py
+++ b/src/core/app_settings.py
@@ -94,8 +94,6 @@ EXIF_CACHE_MIN_FILE_SIZE = 4096  # 4 KB minimum file size for disk caching
 DEFAULT_RATING_CACHE_SIZE_LIMIT_MB = 256  # Default 256MB limit for rating cache
 
 # --- File Operation Constants ---
-# Rotation timeout
-JPEGTRAN_TIMEOUT_SECONDS = 5  # Timeout for jpegtran version check
 
 # --- Image Processing Constants ---
 # Image size settings

--- a/src/core/image_processing/image_rotator.py
+++ b/src/core/image_processing/image_rotator.py
@@ -15,6 +15,14 @@ logger = logging.getLogger(__name__)
 # Rotation directions
 RotationDirection = Literal["clockwise", "counterclockwise", "180"]
 
+"""
+Handles image rotation with support for:
+1. Standard rotation for JPEG, PNG and other formats  
+2. Metadata-only rotation for RAW formats (ARW, CR2, NEF, etc.)
+3. Metadata-only rotation for HEIF/HEIC formats
+4. XMP orientation metadata updates for all supported formats
+"""
+
 
 class ImageRotator:
     # Define supported image formats for different rotation types
@@ -48,16 +56,6 @@ class ImageRotator:
         ".heif",
         ".heic",
     }
-    """
-    Handles image rotation with support for:
-    1. Standard rotation for JPEG, PNG and other formats  
-    2. Metadata-only rotation for RAW formats (ARW, CR2, NEF, etc.)
-    3. Metadata-only rotation for HEIF/HEIC formats
-    4. XMP orientation metadata updates for all supported formats
-    """
-
-    def __init__(self):
-        pass
 
     def _get_current_orientation(self, image_path: str) -> int:
         """Get current EXIF orientation value (1-8, default 1)."""

--- a/src/core/image_processing/image_rotator.py
+++ b/src/core/image_processing/image_rotator.py
@@ -1,3 +1,11 @@
+"""
+Handles image rotation with support for:
+1. Standard rotation for JPEG, PNG and other formats
+2. Metadata-only rotation for RAW formats (ARW, CR2, NEF, etc.)
+3. Metadata-only rotation for HEIF/HEIC formats
+4. XMP orientation metadata updates for all supported formats
+"""
+
 import os
 import logging
 from typing import Literal, Tuple
@@ -14,14 +22,6 @@ logger = logging.getLogger(__name__)
 
 # Rotation directions
 RotationDirection = Literal["clockwise", "counterclockwise", "180"]
-
-"""
-Handles image rotation with support for:
-1. Standard rotation for JPEG, PNG and other formats  
-2. Metadata-only rotation for RAW formats (ARW, CR2, NEF, etc.)
-3. Metadata-only rotation for HEIF/HEIC formats
-4. XMP orientation metadata updates for all supported formats
-"""
 
 
 class ImageRotator:
@@ -346,7 +346,7 @@ class ImageRotator:
                 elif pixel_available:
                     # Fallback to pixel rotation
                     success = self._rotate_image_standard(image_path, direction)
-                    method_used = "standard JPEG (quality=95, lossy fallback)"
+                    method_used = "standard JPEG (lossy fallback)"
                 else:
                     success = False
                     method_used = "no available rotation method"

--- a/src/ui/menu_manager.py
+++ b/src/ui/menu_manager.py
@@ -7,7 +7,7 @@ from PyQt6.QtCore import QPoint, Qt
 from PyQt6.QtGui import QAction, QIcon, QKeySequence
 from PyQt6.QtWidgets import QMenu, QStyle, QWidget, QWidgetAction, QHBoxLayout, QLabel
 
-from core.metadata_processor import MetadataProcessor
+from core.image_processing.image_rotator import ImageRotator
 from core.app_settings import get_recent_folders
 
 logger = logging.getLogger(__name__)
@@ -23,6 +23,9 @@ class MenuManager:
         self.main_window = main_window
         self.dialog_manager = main_window.dialog_manager
         self.app_state = main_window.app_state
+
+        # Initialize ImageRotator for fast rotation support checking
+        self.image_rotator = ImageRotator()
 
         # --- Actions ---
         # File Menu
@@ -526,8 +529,8 @@ class MenuManager:
 
         menu = QMenu(main_win)
 
-        # Rotation
-        if MetadataProcessor.is_rotation_supported(file_path):
+        # Rotation - use ImageRotator's fast extension-based check to avoid PyExiv2 operations in windowed builds
+        if self.image_rotator.is_rotation_supported(file_path):
             selected_paths = main_win._get_selected_file_paths_from_view()
             num_selected = len(selected_paths) if len(selected_paths) > 1 else 1
             label_suffix = f" {num_selected} Images" if num_selected > 1 else ""

--- a/tests/test_image_rotator.py
+++ b/tests/test_image_rotator.py
@@ -74,7 +74,7 @@ class TestImageRotator:
     def test_rotator_initialization(self):
         """Test that ImageRotator initializes correctly."""
         assert isinstance(self.rotator, ImageRotator)
-        # ImageRotator should initialize without issues
+        # Verify that ImageRotator initializes successfully without requiring external dependencies or configuration
 
     def test_get_supported_formats(self):
         """Test that supported formats are returned correctly."""


### PR DESCRIPTION
This pull request refactors the image rotation logic to remove dependency on the external `jpegtran` tool, streamlining rotation support and simplifying both the codebase and usage. JPEG rotation now prioritizes metadata-only (lossless) rotation, with standard pixel rotation as a fallback. The UI and tests are updated to reflect these changes, improving reliability and cross-platform compatibility.

**Image Rotation Logic Refactor:**

* Removed all code related to `jpegtran` for lossless JPEG rotation, including checks for its availability and the associated timeout constant in `app_settings.py`. JPEG rotation now uses metadata-only rotation first, falling back to pixel rotation if necessary. (`src/core/image_processing/image_rotator.py`, `src/core/app_settings.py`) [[1]](diffhunk://#diff-0f3bda4f81336fd3296a11d23be713314ac29ed2f2c038a3a5844ca9a209ed78L3-L13) [[2]](diffhunk://#diff-7692944c2605b0f9876367f27fc7fb7c1bb2ac313c01d08b3f787e68208a5492L97-L98) [[3]](diffhunk://#diff-0f3bda4f81336fd3296a11d23be713314ac29ed2f2c038a3a5844ca9a209ed78L55-L81) [[4]](diffhunk://#diff-0f3bda4f81336fd3296a11d23be713314ac29ed2f2c038a3a5844ca9a209ed78L147-L217)
* Updated rotation support checks and reporting to reflect the new approach, ensuring that JPEG files attempt metadata rotation before pixel rotation and updating user-facing messages accordingly. (`src/core/image_processing/image_rotator.py`) [[1]](diffhunk://#diff-0f3bda4f81336fd3296a11d23be713314ac29ed2f2c038a3a5844ca9a209ed78L432-R352) [[2]](diffhunk://#diff-0f3bda4f81336fd3296a11d23be713314ac29ed2f2c038a3a5844ca9a209ed78L554-R465)

**User Interface Updates:**

* The UI now uses `ImageRotator` for rotation support checks, replacing the previous use of `MetadataProcessor`. This allows for faster extension-based checks and avoids unnecessary PyExiv2 operations. (`src/ui/menu_manager.py`) [[1]](diffhunk://#diff-6a69d14f37dcc5fdfee5f21035dbbd3e8a688bda477cac0d6ef08901383d513aL10-R10) [[2]](diffhunk://#diff-6a69d14f37dcc5fdfee5f21035dbbd3e8a688bda477cac0d6ef08901383d513aR27-R29) [[3]](diffhunk://#diff-6a69d14f37dcc5fdfee5f21035dbbd3e8a688bda477cac0d6ef08901383d513aL529-R533)

**Testing Improvements:**

* Tests have been updated to remove dependency on `jpegtran` and to validate the new rotation logic, including metadata-first rotation for JPEGs and metadata-only rotation for RAW formats. New tests confirm correct method reporting and ensure file integrity for RAW formats. (`tests/test_image_rotator.py`) [[1]](diffhunk://#diff-6508240a5f2b337b6aaa3035ba9fbb7570928625b75e459b5163cad0b41198e6L77-R77) [[2]](diffhunk://#diff-6508240a5f2b337b6aaa3035ba9fbb7570928625b75e459b5163cad0b41198e6R198-R286)

**Documentation Updates:**

* The README has been updated to remove references to `jpegtran` as a prerequisite, reflecting the simplified rotation support. (`README.md`)