### PR TITLE
fix: Add runtime hook to PyInstaller build for macOS

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -174,6 +174,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           pyinstaller -w --name PhotoSort \
+            --runtime-hook runtime_hook.py \
             --icon assets/photosort.icns \
             --paths src \
             --hidden-import core.build_info \


### PR DESCRIPTION
This pull request introduces a minor update to the macOS build process in the GitHub Actions workflow. The change adds a new runtime hook to the PyInstaller command, which can be used to customize the application's runtime behavior.

* Build process update:
  * [`.github/workflows/release-build.yml`](diffhunk://#diff-52120b4145bd2cf9c735193f6a093a7944688b21f04e854447e34a5049fc829fR177): Added `--runtime-hook runtime_hook.py` to the PyInstaller command for macOS builds.