### PR TITLE
Keep large-image navigation responsive

### DIFF
--- a/src/core/app_settings.py
+++ b/src/core/app_settings.py
@@ -174,6 +174,7 @@ THUMBNAIL_MAX_WORKERS = 4  # Max concurrent thumbnail generation threads
 IMAGE_PIPELINE_MAX_WORKERS = 4  # Keep concurrent decodes below memory pressure limits
 HIGH_MEMORY_DECODE_MAX_WORKERS = 1  # RAW/HEIC full decodes can use hundreds of MB
 IMAGE_MEMORY_CACHE_SIZE_BYTES = 256 * 1024 * 1024  # Shared hot-image budget
+NAVIGATION_PREVIEW_LOOKAHEAD = 4  # Selected image plus a small directional buffer
 
 # Preview size estimation
 # Preview cache payload for this app is usually well below original image bytes,

--- a/src/core/image_pipeline.py
+++ b/src/core/image_pipeline.py
@@ -760,9 +760,13 @@ class ImagePipeline:
             f"Thumbnail preloading finished. Processed {processed_count}/{total_files}."
         )
 
-    def _ensure_preview_generated_and_cached(self, image_path: str) -> bool:
+    def ensure_preview_cached(self, image_path: str) -> bool:
         """
-        Worker function for preload_previews. Generates and caches one preview at PRELOAD_MAX_RESOLUTION.
+        Generate and cache one navigation-sized preview when it is missing.
+
+        This method is safe to call from a background worker. It deliberately
+        stores a bounded PRELOAD_MAX_RESOLUTION image instead of decoding at the
+        larger display size, which keeps navigation prefetch memory predictable.
         Automatically applies auto-edits for RAW files.
         Returns True if successful or already cached, False on error.
         """
@@ -840,7 +844,7 @@ class ImagePipeline:
                     )
                     break
                 future = executor.submit(
-                    self._ensure_preview_generated_and_cached,
+                    self.ensure_preview_cached,
                     image_path,
                 )
                 futures_map[future] = image_path

--- a/src/ui/app_controller.py
+++ b/src/ui/app_controller.py
@@ -356,6 +356,7 @@ class AppController(QObject):
 
         self.app_state.clear_all_file_specific_data()
         self.main_window.reset_thumbnail_requests()
+        self.main_window.reset_preview_requests()
         self.main_window.invalidate_last_displayed_preview()
         self.app_state.current_folder_path = folder_path
         self.app_state.skip_grouping_step_once = skip_grouping_step

--- a/src/ui/controllers/navigation_controller.py
+++ b/src/ui/controllers/navigation_controller.py
@@ -4,6 +4,8 @@ from PyQt6.QtCore import QModelIndex, Qt
 from PyQt6.QtWidgets import QAbstractItemView
 import logging
 
+from core.app_settings import NAVIGATION_PREVIEW_LOOKAHEAD
+
 logger = logging.getLogger(__name__)
 
 
@@ -20,6 +22,7 @@ class NavigationContext(Protocol):
     def validate_and_select_image_candidate(
         self, proxy_index: QModelIndex, direction: str, log_skip: bool
     ): ...
+    def prefetch_navigation_previews(self, image_paths: List[str]) -> None: ...
 
 
 def navigate_group_cyclic(
@@ -152,6 +155,20 @@ class NavigationController:
             all_visible, current_path, direction, skip_deleted, deleted_set
         )
         if target_path:
+            target_position = all_visible.index(target_path)
+            step = -1 if direction in ("up", "left") else 1
+            preview_paths = [target_path]
+            position = target_position
+            while len(preview_paths) <= NAVIGATION_PREVIEW_LOOKAHEAD:
+                position += step
+                if position < 0 or position >= len(all_visible):
+                    break
+                candidate = all_visible[position]
+                if not skip_deleted or candidate not in deleted_set:
+                    preview_paths.append(candidate)
+            prefetch = getattr(self.ctx, "prefetch_navigation_previews", None)
+            if callable(prefetch):
+                prefetch(preview_paths)
             proxy_idx = self.ctx.find_proxy_index_for_path(target_path)
             if proxy_idx.isValid():
                 self.ctx.validate_and_select_image_candidate(

--- a/src/ui/controllers/preview_load_controller.py
+++ b/src/ui/controllers/preview_load_controller.py
@@ -1,0 +1,93 @@
+"""Coordinates responsive, bounded preview loading during navigation."""
+
+from __future__ import annotations
+
+from threading import Event
+from typing import Iterable
+
+from PyQt6.QtCore import QObject, QThreadPool, pyqtSignal
+
+from core.image_pipeline import ImagePipeline
+from workers.preview_prefetch_worker import PreviewPrefetchWorker
+
+
+class PreviewLoadController(QObject):
+    """Keep only the newest navigation preview request alive."""
+
+    preview_ready = pyqtSignal(str)
+    preview_failed = pyqtSignal(str)
+
+    def __init__(
+        self,
+        image_pipeline: ImagePipeline,
+        parent: QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._image_pipeline = image_pipeline
+        self._pool = QThreadPool(self)
+        self._pool.setMaxThreadCount(1)
+        self._request_id = 0
+        self._cancel_event: Event | None = None
+        self._primary_path: str | None = None
+        self._requested_paths: tuple[str, ...] = ()
+
+    def request(self, image_paths: Iterable[str]) -> None:
+        ordered_paths = tuple(dict.fromkeys(path for path in image_paths if path))
+        if not ordered_paths:
+            return
+
+        primary_path = ordered_paths[0]
+        if (
+            primary_path == self._primary_path
+            and set(ordered_paths).issubset(self._requested_paths)
+            and self._cancel_event is not None
+            and not self._cancel_event.is_set()
+        ):
+            return
+
+        self.cancel()
+        self._request_id += 1
+        request_id = self._request_id
+        cancel_event = Event()
+        self._cancel_event = cancel_event
+        self._primary_path = primary_path
+        self._requested_paths = ordered_paths
+
+        worker = PreviewPrefetchWorker(
+            ordered_paths,
+            self._image_pipeline,
+            cancel_event,
+            request_id,
+        )
+        worker.signals.preview_ready.connect(self._handle_preview_ready)
+        worker.signals.preview_failed.connect(self._handle_preview_failed)
+        worker.signals.finished.connect(self._handle_finished)
+        self._pool.start(worker)
+
+    def cancel(self) -> None:
+        if self._cancel_event is not None:
+            self._cancel_event.set()
+        # Drop queued stale work. A decode already in progress exits after its
+        # current file, and its result is ignored using the request id.
+        self._pool.clear()
+
+    def reset(self) -> None:
+        self.cancel()
+        self._primary_path = None
+        self._requested_paths = ()
+
+    def shutdown(self) -> None:
+        self.reset()
+        self._pool.waitForDone(5000)
+
+    def _handle_preview_ready(self, image_path: str, request_id: int) -> None:
+        if request_id == self._request_id:
+            self.preview_ready.emit(image_path)
+
+    def _handle_preview_failed(self, image_path: str, request_id: int) -> None:
+        if request_id == self._request_id:
+            self.preview_failed.emit(image_path)
+
+    def _handle_finished(self, request_id: int) -> None:
+        if request_id == self._request_id:
+            self._cancel_event = None

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -87,6 +87,7 @@ from ui.controllers.similarity_controller import SimilarityController
 from ui.controllers.metadata_controller import MetadataController
 from ui.controllers.cache_controller import CacheController
 from ui.controllers.status_controller import StatusController
+from ui.controllers.preview_load_controller import PreviewLoadController
 from ui.thumbnail_load_coordinator import ViewportThumbnailLoader
 from ui.models.media_filter_proxy import (
     CustomFilterProxyModel,
@@ -160,6 +161,9 @@ class MainWindow(QMainWindow):
         self.metadata_controller = MetadataController(self)
         self.cache_controller = CacheController(self)
         self.status_controller = StatusController(self)
+        self.preview_load_controller = PreviewLoadController(self.image_pipeline, self)
+        self.preview_load_controller.preview_ready.connect(self._handle_preview_ready)
+        self.preview_load_controller.preview_failed.connect(self._handle_preview_failed)
 
         # Hotkey controller wraps navigation key handling
         self.hotkey_controller = HotkeyController(self)
@@ -671,6 +675,14 @@ class MainWindow(QMainWindow):
 
     def reset_thumbnail_requests(self) -> None:
         self.thumbnail_loader.reset()
+
+    def reset_preview_requests(self) -> None:
+        self.preview_load_controller.reset()
+
+    def prefetch_navigation_previews(self, image_paths: List[str]) -> None:
+        self.preview_load_controller.request(
+            path for path in image_paths if not is_video_extension(path)
+        )
 
     def schedule_visible_thumbnail_load(self, *_args) -> None:
         self.thumbnail_loader.schedule()
@@ -1713,6 +1725,7 @@ class MainWindow(QMainWindow):
 
         self._close_after_grouping_save = False
         logger.info("Stopping all workers on application close.")
+        self.preview_load_controller.shutdown()
         self.worker_manager.stop_all_workers()  # Use WorkerManager to stop all
         event.accept()
 
@@ -2276,15 +2289,16 @@ class MainWindow(QMainWindow):
 
         if not reuse_preview:
             logger.debug(f"Getting preview pixmap for {file_path}")
-            pixmap = self.image_pipeline.get_preview_qpixmap(
+            pixmap = self.image_pipeline.get_cached_preview_qpixmap(
                 file_path, display_max_size=DISPLAY_MAX_RESOLUTION
             )
+            preview_is_cached = bool(pixmap and not pixmap.isNull())
 
-            if not pixmap or pixmap.isNull():
+            if not preview_is_cached:
                 logger.debug(
-                    f"Preview pixmap unavailable, trying thumbnail for {file_path}"
+                    f"Cached preview unavailable, trying cached thumbnail for {file_path}"
                 )
-                pixmap = self.image_pipeline.get_thumbnail_qpixmap(file_path)
+                pixmap = self.image_pipeline.get_cached_thumbnail_qpixmap(file_path)
 
             if pixmap and not pixmap.isNull():
                 logger.debug(f"Setting image data for {file_path}")
@@ -2295,14 +2309,13 @@ class MainWindow(QMainWindow):
                 }
                 self.advanced_image_viewer.set_image_data(image_data)
             else:
-                logger.debug(f"Failed to load image data for {file_path}")
-                self.advanced_image_viewer.setText("Failed to load image")
-                self.statusBar().showMessage(
-                    f"Error: Could not load image data for {os.path.basename(file_path)}",
-                    7000,
-                )
-                self.invalidate_last_displayed_preview()
-                return
+                self.advanced_image_viewer.setText("Loading preview…")
+
+            if not preview_is_cached:
+                # A cache miss must never decode on the UI thread. Keyboard
+                # navigation may already have queued this path and its lookahead;
+                # the controller deduplicates this narrower mouse request.
+                self.preview_load_controller.request([file_path])
 
         self._last_displayed_preview_path = file_path
         self._update_status_bar_for_image(
@@ -2312,6 +2325,43 @@ class MainWindow(QMainWindow):
         if self.sidebar_visible:
             logger.debug("Updating sidebar with current selection")
             self._update_sidebar_with_current_selection()
+
+    def _handle_preview_ready(self, file_path: str) -> None:
+        """Upgrade the current thumbnail only when the result is still relevant."""
+        if self.app_state.focused_image_path != file_path:
+            return
+        pixmap = self.image_pipeline.get_cached_preview_qpixmap(
+            file_path, display_max_size=DISPLAY_MAX_RESOLUTION
+        )
+        if pixmap is None or pixmap.isNull():
+            return
+        metadata = self._get_cached_metadata_for_selection(file_path)
+        if metadata is None:
+            return
+        self.advanced_image_viewer.set_image_data(
+            {
+                "pixmap": pixmap,
+                "path": file_path,
+                "rating": metadata.get("rating", 0),
+            }
+        )
+        self._last_displayed_preview_path = file_path
+        self._update_status_bar_for_image(
+            file_path,
+            metadata,
+            pixmap,
+            self.app_state.get_file_data_by_path(file_path),
+        )
+
+    def _handle_preview_failed(self, file_path: str) -> None:
+        if self.app_state.focused_image_path != file_path:
+            return
+        self.advanced_image_viewer.setText("Failed to load image")
+        self.statusBar().showMessage(
+            f"Error: Could not load image data for {os.path.basename(file_path)}",
+            7000,
+        )
+        self.invalidate_last_displayed_preview()
 
     def _display_single_video_preview(
         self,

--- a/src/workers/preview_prefetch_worker.py
+++ b/src/workers/preview_prefetch_worker.py
@@ -1,0 +1,60 @@
+"""Cancelable background work for the bounded navigation preview buffer."""
+
+from __future__ import annotations
+
+import logging
+from threading import Event
+from typing import Iterable
+
+from PyQt6.QtCore import QObject, QRunnable, pyqtSignal
+
+from core.image_pipeline import ImagePipeline
+
+logger = logging.getLogger(__name__)
+
+
+class PreviewPrefetchSignals(QObject):
+    preview_ready = pyqtSignal(str, int)
+    preview_failed = pyqtSignal(str, int)
+    finished = pyqtSignal(int)
+
+
+class PreviewPrefetchWorker(QRunnable):
+    """Populate preview cache entries without ever creating QPixmaps off-thread."""
+
+    def __init__(
+        self,
+        image_paths: Iterable[str],
+        image_pipeline: ImagePipeline,
+        cancel_event: Event,
+        request_id: int,
+    ) -> None:
+        super().__init__()
+        self.image_paths = tuple(image_paths)
+        self.image_pipeline = image_pipeline
+        self.cancel_event = cancel_event
+        self.request_id = request_id
+        self.signals = PreviewPrefetchSignals()
+
+    def run(self) -> None:
+        try:
+            for image_path in self.image_paths:
+                if self.cancel_event.is_set():
+                    break
+                try:
+                    ready = self.image_pipeline.ensure_preview_cached(image_path)
+                except Exception:
+                    logger.error(
+                        "Navigation preview generation failed for %s",
+                        image_path,
+                        exc_info=True,
+                    )
+                    if not self.cancel_event.is_set():
+                        self.signals.preview_failed.emit(image_path, self.request_id)
+                    continue
+                if ready and not self.cancel_event.is_set():
+                    self.signals.preview_ready.emit(image_path, self.request_id)
+                elif not self.cancel_event.is_set():
+                    self.signals.preview_failed.emit(image_path, self.request_id)
+        finally:
+            self.signals.finished.emit(self.request_id)

--- a/tests/test_navigation_controller.py
+++ b/tests/test_navigation_controller.py
@@ -55,6 +55,7 @@ class Ctx:
         self.paths = list(paths)
         self.deleted = set(deleted or [])
         self.last_selected = None
+        self.prefetched = []
         self.view = DummyView(self)
 
     # Protocol methods
@@ -104,6 +105,9 @@ class Ctx:
         row = proxy_index.row()
         if 0 <= row < len(self.paths):
             self.last_selected = self.paths[row]
+
+    def prefetch_navigation_previews(self, image_paths):
+        self.prefetched = list(image_paths)
 
 
 def test_navigation_group_cyclic_with_deleted_items():
@@ -166,6 +170,16 @@ def test_navigation_linear_includes_deleted_when_skip_false():
     ctx.find_proxy_index_for_path("a")
     nav.navigate_linear("down", skip_deleted=False)  # should land on deleted 'b'
     assert ctx.last_selected == "b"
+
+
+def test_navigation_prefetches_a_small_directional_window_and_skips_deleted():
+    ctx = Ctx(["a", "b", "c", "d", "e", "f"], deleted=["d"])
+    nav = NavigationController(ctx)
+    ctx.find_proxy_index_for_path("a")
+
+    nav.navigate_linear("down", skip_deleted=True)
+
+    assert ctx.prefetched == ["b", "c", "e", "f"]
 
 
 def test_navigation_group_includes_deleted_when_skip_false():

--- a/tests/test_preview_load_controller.py
+++ b/tests/test_preview_load_controller.py
@@ -1,0 +1,62 @@
+from core.app_settings import NAVIGATION_PREVIEW_LOOKAHEAD
+from ui.controllers.preview_load_controller import PreviewLoadController
+
+
+class _Pipeline:
+    def __init__(self):
+        self.generated = []
+
+    def ensure_preview_cached(self, path):
+        self.generated.append(path)
+        return True
+
+
+class _Pool:
+    def __init__(self):
+        self.started = []
+        self.clear_count = 0
+
+    def start(self, worker):
+        self.started.append(worker)
+
+    def clear(self):
+        self.clear_count += 1
+
+    def waitForDone(self, _timeout):
+        return True
+
+
+def test_same_primary_request_keeps_existing_lookahead_work():
+    pipeline = _Pipeline()
+    controller = PreviewLoadController(pipeline)
+    pool = _Pool()
+    controller._pool = pool
+
+    paths = [f"image-{index}.jpg" for index in range(NAVIGATION_PREVIEW_LOOKAHEAD + 1)]
+    controller.request(paths)
+    controller.request([paths[0]])
+
+    assert len(pool.started) == 1
+    pool.started[0].run()
+    assert pipeline.generated == paths
+
+
+def test_new_selection_cancels_stale_work_and_only_emits_latest_result():
+    pipeline = _Pipeline()
+    controller = PreviewLoadController(pipeline)
+    pool = _Pool()
+    controller._pool = pool
+    ready = []
+    controller.preview_ready.connect(ready.append)
+
+    controller.request(["old.jpg", "old-next.jpg"])
+    old_worker = pool.started[-1]
+    controller.request(["current.jpg"])
+    current_worker = pool.started[-1]
+
+    old_worker.run()
+    current_worker.run()
+
+    assert pipeline.generated == ["current.jpg"]
+    assert ready == ["current.jpg"]
+    assert pool.clear_count >= 2


### PR DESCRIPTION
## What changed

- moved cold preview decoding off the Qt UI thread
- added a single-worker, cancelable preview queue that keeps only the newest navigation request
- prefetched a bounded directional window of four upcoming images
- displayed cached previews or thumbnails immediately and upgraded only the still-selected image
- reset and shut down preview work cleanly on folder changes and app exit

## Why

The global preview preload was removed to improve startup, but an uncached selection then fell back to synchronous large-image decoding. Holding the arrow keys could therefore block the event loop on every image.

This keeps startup lazy while making navigation responsive and avoids decoding an entire folder or wasting work on images the user has already skipped.

## Validation

- `ruff check` on all changed Python files
- `pytest -q` — 478 passed
- cold-cache test with an 8000×6000 JPEG: UI request submission ~0.2 ms; ~259 ms decode completed in the background