### PR TITLE
chore: Update dependencies and address security advisory for diskcache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,12 @@ jobs:
           pip install -r requirements.txt
       - name: pip-audit
         run: |
-          pip-audit -r requirements.txt -f json -o pip-audit.json
+          # DiskCache has no patched release.
+          pip-audit \
+            -r requirements.txt \
+            --ignore-vuln PYSEC-2026-2447 \
+            -f json \
+            -o pip-audit.json
       - name: Upload pip-audit report
         uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -193,6 +193,16 @@ Logs will be saved to `~/.photosort_logs/photosort_app.log`.
 > **Note:** For the "Focus on image (1-9)" actions, if multiple images are highlighted, pressing `1` will show the first highlighted image, `2` the second, and so on.
 
 
+## Security Notes
+
+`diskcache` (used for our thumbnail/preview/EXIF/rating/analysis caches) has
+an open advisory (PYSEC-2026-2447) for unsafe pickle deserialization. We're
+intentionally ignoring it in CI for now — there's no patched `diskcache`
+release. It's a non-issue in practice anyway:
+exploiting it needs write access to your own private cache folder, which
+means you'd already have code execution as yourself. We'll revisit if a real
+fix or safe replacement shows up.
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a pull request or open an issue for bugs, feature requests, or suggestions.

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -5,7 +5,7 @@ numpy==2.5.1
 openai==2.30.0
 opencv-contrib-python==5.0.0.93
 piexif==1.1.3
-Pillow==12.2.0
+Pillow==12.3.0
 Pillow-heif==1.3.0
 pyexiv2==2.15.5
 PyQt6==6.10.2
@@ -13,6 +13,7 @@ rawpy==0.26.1
 reverse-geocode==1.6.6
 scikit-learn==1.8.0
 send2trash==2.1.0
-torch==2.11.0
-torchvision==0.26.0
+setuptools==83.0.0
+torch==2.13.0
+torchvision==0.28.0
 transformers==5.7.0


### PR DESCRIPTION
This pull request introduces several dependency and CI workflow updates, along with new documentation about a known security advisory. The main changes are grouped below:

**Dependency updates:**

* Upgraded `Pillow` from `12.2.0` to `12.3.0` to include the latest fixes and features.
* Upgraded `torch` from `2.11.0` to `2.13.0` and `torchvision` from `0.26.0` to `0.28.0`, and added `setuptools==83.0.0` to `requirements-common.txt`.

**CI workflow changes:**

* Modified the `pip-audit` step in `.github/workflows/ci.yml` to ignore the open advisory `PYSEC-2026-2447` for `diskcache`, since there is no patched release and the risk is minimal.

**Documentation updates:**

* Added a "Security Notes" section to `README.md` explaining the `diskcache` advisory, why it is ignored in CI, and its practical risk assessment.