### PR TITLE
feat: Cache warning in case of overflow

### DIFF
--- a/src/core/app_settings.py
+++ b/src/core/app_settings.py
@@ -93,7 +93,8 @@ def get_huggingface_cache_dir() -> str:
 
 # Default values
 DEFAULT_PREVIEW_CACHE_SIZE_GB = 2.0  # Default to 2 GB for preview cache
-DEFAULT_EXIF_CACHE_SIZE_MB = 256  # Default to 256 MB for EXIF cache
+DEFAULT_EXIF_CACHE_SIZE_MB = 2048  # Default to 2 GB for EXIF cache
+MAX_EXIF_CACHE_SIZE_MB = 5120  # Largest selectable EXIF cache limit (5 GB)
 DEFAULT_ROTATION_CONFIRM_LOSSY = True  # Default to asking before lossy rotation
 DEFAULT_SHOW_WORKFLOW_SHORTCUTS = True
 DEFAULT_WORKFLOW_STEP_VISIBILITY = dict.fromkeys(WORKFLOW_STEP_VISIBILITY_KEYS, True)

--- a/src/core/caching/exif_cache.py
+++ b/src/core/caching/exif_cache.py
@@ -3,6 +3,8 @@ import os
 import logging
 import time
 import threading
+import unicodedata
+from collections.abc import Iterable
 from typing import Any
 from core.runtime_paths import resolve_user_cache_dir
 
@@ -156,6 +158,31 @@ class ExifCache:
         except Exception as e:
             logger.error(f"Error getting EXIF cache volume: {e}", exc_info=True)
             return 0
+
+    def dataset_residency(self, keys: Iterable[str]) -> tuple[int, int]:
+        """Return how many unique dataset keys are still present in the cache."""
+        canonical_keys = {
+            unicodedata.normalize("NFC", os.path.normpath(key))
+            for key in keys
+            if key
+        }
+        try:
+            resident_count = sum(key in self._cache for key in canonical_keys)
+            return resident_count, len(canonical_keys)
+        except Exception:
+            logger.error("Error checking EXIF dataset cache residency.", exc_info=True)
+            # Suppress a capacity warning when residency could not be measured.
+            return len(canonical_keys), len(canonical_keys)
+
+    def is_near_capacity(self, threshold: float = 0.95) -> bool:
+        """Whether disk usage is close enough to the limit for eviction churn."""
+        if self._size_limit_bytes <= 0:
+            return False
+        return self.volume() >= int(self._size_limit_bytes * threshold)
+
+    def get_current_size_limit_bytes(self) -> int:
+        """Return the configured cache limit in bytes."""
+        return self._size_limit_bytes
 
     def get_current_size_limit_mb(self) -> int:
         """Returns the current configured size limit in MB."""

--- a/src/ui/app_controller.py
+++ b/src/ui/app_controller.py
@@ -157,6 +157,7 @@ class AppController(QObject):
         self._pending_grouping_preview: tuple[object, str] | None = None
         self._cancelled_workflows: set[str] = set()
         self._ignore_similarity_results = False
+        self._pending_exif_cache_capacity_warning: tuple[int, int, int] | None = None
 
     def is_workflow_analysis_running(self, workflow: str) -> bool:
         if workflow == "organize":
@@ -248,6 +249,9 @@ class AppController(QObject):
             self.handle_rating_load_finished
         )
         self.worker_manager.rating_load_error.connect(self.handle_rating_load_error)
+        self.worker_manager.rating_load_cache_capacity_warning.connect(
+            self.handle_exif_cache_capacity_warning
+        )
 
         # Rotation Detection Worker
         self.worker_manager.rotation_detection_progress.connect(
@@ -411,8 +415,10 @@ class AppController(QObject):
             self.app_state.marked_for_deletion.update(preserved_marks)
         self.main_window.reset_thumbnail_requests()
         self.main_window.reset_preview_requests()
+        self.main_window.hide_exif_progress()
         self.main_window.invalidate_last_displayed_preview()
         self._pending_grouping_preview = None
+        self._pending_exif_cache_capacity_warning = None
         self.app_state.current_folder_path = folder_path
         self.app_state.skip_grouping_step_once = skip_grouping_step
         if record_as_source:
@@ -1681,10 +1687,7 @@ class AppController(QObject):
             finish_transition(successful, failed)
 
     def handle_rating_load_progress(self, current: int, total: int, basename: str):
-        percentage = int((current / total) * 100) if total > 0 else 0
-        self.main_window.update_loading_text(
-            f"Loading ratings: {percentage}% ({current}/{total}) - {basename}"
-        )
+        self.main_window.set_exif_progress(current, total)
 
     def handle_metadata_batch_loaded(
         self, metadata_batch: list[tuple[str, dict[str, Any]]]
@@ -1715,11 +1718,39 @@ class AppController(QObject):
         )
 
         self.main_window.hide_loading_overlay()
+        self.main_window.hide_exif_progress()
+
+        warning = self._pending_exif_cache_capacity_warning
+        self._pending_exif_cache_capacity_warning = None
+        if warning is not None:
+            dataset_entries, resident_entries, cache_limit_bytes = warning
+            QTimer.singleShot(
+                0,
+                lambda: self.main_window.dialog_manager.show_exif_cache_capacity_warning(
+                    dataset_entries,
+                    resident_entries,
+                    cache_limit_bytes,
+                ),
+            )
+
+    def handle_exif_cache_capacity_warning(
+        self,
+        dataset_entries: int,
+        resident_entries: int,
+        cache_limit_bytes: int,
+    ) -> None:
+        """Defer the modal warning until background metadata loading finishes."""
+        self._pending_exif_cache_capacity_warning = (
+            dataset_entries,
+            resident_entries,
+            cache_limit_bytes,
+        )
 
     def handle_rating_load_error(self, message: str):
         logger.error(f"Rating load failed: {message}", exc_info=True)
         self.main_window.statusBar().showMessage(f"Rating Load Error: {message}", 5000)
         self.main_window.hide_loading_overlay()
+        self.main_window.hide_exif_progress()
 
     def handle_similarity_progress(self, percentage, message):
         if getattr(self, "_ignore_similarity_results", False):

--- a/src/ui/controllers/cache_controller.py
+++ b/src/ui/controllers/cache_controller.py
@@ -52,7 +52,12 @@ class CacheController:
         exif_cache = getattr(ctx.app_state, "exif_disk_cache", None)
         if exif_cache:
             configured_mb = exif_cache.get_current_size_limit_mb()
-            ctx.exif_cache_configured_limit_label.setText(f"{configured_mb} MB")
+            configured_text = (
+                f"{configured_mb / 1024:.2f} GB"
+                if configured_mb >= 1024
+                else f"{configured_mb} MB"
+            )
+            ctx.exif_cache_configured_limit_label.setText(configured_text)
             ctx.exif_cache_usage_label.setText(
                 f"{exif_cache.volume() / (1024 * 1024):.2f} MB"
             )
@@ -184,11 +189,13 @@ class CacheController:
                 set_exif_cache_size_mb(new_size_mb)
                 exif_cache.reinitialize_from_settings()
                 ctx.status_message(
-                    f"EXIF cache limit set to {new_size_mb} MB. Cache reinitialized.",
+                    f"EXIF cache limit set to {new_size_mb / 1024:.2f} GB. "
+                    "Cache reinitialized.",
                     5000,
                 )
             else:
                 ctx.status_message(
-                    f"EXIF cache limit is already {new_size_mb} MB.", 3000
+                    f"EXIF cache limit is already {new_size_mb / 1024:.2f} GB.",
+                    3000,
                 )
         self.update_labels()

--- a/src/ui/dialog_manager.py
+++ b/src/ui/dialog_manager.py
@@ -42,6 +42,7 @@ from core.app_settings import (
     get_workflow_step_visibility,
     get_preview_cache_size_gb,
     get_exif_cache_size_mb,
+    MAX_EXIF_CACHE_SIZE_MB,
     set_easy_delete_blur_threshold,
     set_easy_delete_dark_threshold,
     set_easy_delete_duplicate_distance,
@@ -1915,9 +1916,20 @@ class DialogManager:
 
         self.parent.exif_cache_size_combo = QComboBox()
         self.parent.exif_cache_size_combo.setObjectName("exifCacheSizeCombo")
-        self.parent.exif_cache_size_options_mb = [64, 128, 256, 512, 1024]
+        self.parent.exif_cache_size_options_mb = [
+            256,
+            512,
+            1024,
+            2048,
+            3072,
+            4096,
+            MAX_EXIF_CACHE_SIZE_MB,
+        ]
         self.parent.exif_cache_size_combo.addItems(
-            [f"{size} MB" for size in self.parent.exif_cache_size_options_mb]
+            [
+                f"{size // 1024} GB" if size % 1024 == 0 else f"{size} MB"
+                for size in self.parent.exif_cache_size_options_mb
+            ]
         )
         current_exif_conf_mb = get_exif_cache_size_mb()
         try:
@@ -2157,6 +2169,41 @@ class DialogManager:
         )
         warn_box.exec()
         logger.info("Closed potential cache overflow warning dialog")
+
+    def show_exif_cache_capacity_warning(
+        self,
+        dataset_entries: int,
+        resident_entries: int,
+        cache_limit_bytes: int,
+    ) -> None:
+        """Warn when metadata for the current folder cannot remain cached."""
+        evicted_entries = max(0, dataset_entries - resident_entries)
+        cache_limit_gb = cache_limit_bytes / (1024 * 1024 * 1024)
+        warning_msg = (
+            f"The EXIF metadata for this folder does not fit in the configured "
+            f"{cache_limit_gb:.2f} GB cache.\n\n"
+            f"{evicted_entries:,} of {dataset_entries:,} entries were evicted while "
+            "the folder was loading. Those files will require metadata extraction "
+            "again the next time this folder is opened.\n\n"
+            "Increase the EXIF Metadata limit in Settings > Manage Cache."
+        )
+
+        logger.warning(
+            "Showing EXIF cache capacity warning: resident=%d total=%d limit=%.2f GB",
+            resident_entries,
+            dataset_entries,
+            cache_limit_gb,
+        )
+        warn_box = QMessageBox(self.parent)
+        warn_box.setIcon(QMessageBox.Icon.Warning)
+        warn_box.setWindowTitle("EXIF Cache Too Small")
+        warn_box.setText(warning_msg)
+        warn_box.setStandardButtons(QMessageBox.StandardButton.Ok)
+        warn_box.setDefaultButton(QMessageBox.StandardButton.Ok)
+        warn_box.setWindowFlags(
+            warn_box.windowFlags() | Qt.WindowType.FramelessWindowHint
+        )
+        warn_box.exec()
 
     def show_commit_deletions_dialog(self, marked_files: list[str]) -> bool:
         """

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -553,6 +553,19 @@ class MainWindow(QMainWindow):
         thumbnail_progress_layout.addWidget(self.thumbnail_progress_bar)
         self.thumbnail_progress_container.setVisible(False)
         self.workflow_footer_right_layout.addWidget(self.thumbnail_progress_container)
+
+        self.exif_progress_container = QWidget()
+        exif_progress_layout = QHBoxLayout(self.exif_progress_container)
+        exif_progress_layout.setContentsMargins(6, 0, 6, 0)
+        exif_progress_layout.setSpacing(6)
+        self.exif_progress_label = QLabel()
+        self.exif_progress_bar = QProgressBar()
+        self.exif_progress_bar.setTextVisible(False)
+        self.exif_progress_bar.setFixedWidth(110)
+        exif_progress_layout.addWidget(self.exif_progress_label)
+        exif_progress_layout.addWidget(self.exif_progress_bar)
+        self.exif_progress_container.setVisible(False)
+        self.workflow_footer_right_layout.addWidget(self.exif_progress_container)
         logger.debug(f"Widgets created in {time.perf_counter() - start_time:.4f}s.")
 
     def _create_layout(self):
@@ -1068,6 +1081,25 @@ class MainWindow(QMainWindow):
 
     def hide_thumbnail_progress(self) -> None:
         self.thumbnail_progress_container.setVisible(False)
+
+    def set_exif_progress(self, current: int, total: int) -> None:
+        """Show background EXIF preparation independently of thumbnails."""
+        if total <= 0:
+            self.hide_exif_progress()
+            return
+        if current <= 0:
+            self.exif_progress_label.setText("Preparing EXIF data…")
+            self.exif_progress_bar.setRange(0, 0)
+        else:
+            self.exif_progress_label.setText(
+                f"Preparing EXIF data {current:,} / {total:,}"
+            )
+            self.exif_progress_bar.setRange(0, total)
+            self.exif_progress_bar.setValue(min(current, total))
+        self.exif_progress_container.setVisible(True)
+
+    def hide_exif_progress(self) -> None:
+        self.exif_progress_container.setVisible(False)
 
     def reset_preview_requests(self) -> None:
         self.preview_load_controller.reset()

--- a/src/ui/worker_manager.py
+++ b/src/ui/worker_manager.py
@@ -74,6 +74,7 @@ class WorkerManager(QObject):
     )  # List of tuples: [(image_path, metadata_dict), ...]
     rating_load_finished = pyqtSignal()
     rating_load_error = pyqtSignal(str)
+    rating_load_cache_capacity_warning = pyqtSignal(int, int, object)
 
     # Rotation Detection Signals
     rotation_detection_progress = pyqtSignal(int, int, str)  # current, total, basename
@@ -504,6 +505,9 @@ class WorkerManager(QObject):
         )  # Connect to the new batched signal
         self.rating_loader_worker.finished.connect(self.rating_load_finished)
         self.rating_loader_worker.error.connect(self.rating_load_error)
+        self.rating_loader_worker.cache_capacity_warning.connect(
+            self.rating_load_cache_capacity_warning
+        )
 
         self.rating_loader_thread.started.connect(self.rating_loader_worker.run_load)
         self.rating_load_finished.connect(self.rating_loader_thread.quit)

--- a/src/workers/rating_loader_worker.py
+++ b/src/workers/rating_loader_worker.py
@@ -39,6 +39,8 @@ class RatingLoaderWorker(QObject):
     )  # List of tuples: [(image_path, metadata_dict), ...]
     finished = pyqtSignal()
     error = pyqtSignal(str)
+    cache_capacity_warning = pyqtSignal(int, int, object)
+    # unique dataset entries, resident entries, configured limit bytes
 
     def __init__(
         self,
@@ -96,6 +98,7 @@ class RatingLoaderWorker(QObject):
 
         total_load_start_time = time.perf_counter()
         logger.info(f"Starting metadata load for {total_files} files.")
+        self._emit(self.progress_update, 0, total_files, "")
 
         try:
             # Single batch call to the refactored MetadataHandler
@@ -103,6 +106,19 @@ class RatingLoaderWorker(QObject):
                 image_paths_to_process,
                 self._rating_disk_cache,
                 self._app_state.exif_disk_cache,
+            )
+
+            resident_entries, dataset_entries = (
+                self._app_state.exif_disk_cache.dataset_residency(
+                    image_paths_to_process
+                )
+            )
+            cache_limit_bytes = (
+                self._app_state.exif_disk_cache.get_current_size_limit_bytes()
+            )
+            dataset_exceeds_cache = (
+                resident_entries < dataset_entries
+                and self._app_state.exif_disk_cache.is_near_capacity()
             )
 
             metadata_batch_to_emit = []
@@ -192,6 +208,21 @@ class RatingLoaderWorker(QObject):
                 )
                 self._emit(self.metadata_batch_loaded, list(metadata_batch_to_emit))
                 metadata_batch_to_emit.clear()
+
+            if dataset_exceeds_cache:
+                logger.warning(
+                    "Current dataset does not fit in the EXIF cache: "
+                    "resident=%d total=%d limit=%.2f GB",
+                    resident_entries,
+                    dataset_entries,
+                    cache_limit_bytes / (1024 * 1024 * 1024),
+                )
+                self._emit(
+                    self.cache_capacity_warning,
+                    dataset_entries,
+                    resident_entries,
+                    cache_limit_bytes,
+                )
 
         except Exception as e:
             error_msg = f"An error occurred during metadata loading: {e}"

--- a/tests/test_app_controller_video_support.py
+++ b/tests/test_app_controller_video_support.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 from src.ui.app_controller import AppController
 
@@ -42,6 +42,8 @@ class _DummyMainWindow:
         self.overlay_hidden = False
         self.schedule_visible_thumbnail_load = Mock()
         self.start_thumbnail_warming = Mock()
+        self.set_exif_progress = Mock()
+        self.hide_exif_progress = Mock()
 
     def update_loading_text(self, text):
         self._loading_updates.append(text)
@@ -126,6 +128,19 @@ def test_rating_completion_does_not_trigger_global_preview_preload():
 
     worker_manager.start_preview_preload.assert_not_called()
     assert main_window.overlay_hidden
+    main_window.hide_exif_progress.assert_called_once_with()
+
+
+def test_rating_progress_updates_the_exif_footer_progress():
+    controller, main_window, _, _ = _make_controller([])
+
+    controller.handle_rating_load_progress(0, 4_482, "")
+    controller.handle_rating_load_progress(250, 4_482, "photo.arw")
+
+    assert main_window.set_exif_progress.call_args_list == [
+        call(0, 4_482),
+        call(250, 4_482),
+    ]
 
 
 def test_apply_rating_to_selection_skips_videos_and_writes_images_only():

--- a/tests/test_exif_cache_capacity.py
+++ b/tests/test_exif_cache_capacity.py
@@ -1,0 +1,94 @@
+import pyexiv2  # noqa: F401  # Must be first to avoid Windows crashes
+
+import unicodedata
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from core import app_settings
+from core.caching.exif_cache import ExifCache
+from ui.app_controller import AppController
+from workers.rating_loader_worker import RatingLoaderWorker
+
+
+def test_exif_cache_defaults_to_two_gb_and_caps_selector_at_five_gb():
+    assert app_settings.DEFAULT_EXIF_CACHE_SIZE_MB == 2 * 1024
+    assert app_settings.MAX_EXIF_CACHE_SIZE_MB == 5 * 1024
+
+
+def test_dataset_residency_uses_unique_canonical_paths():
+    cache = ExifCache.__new__(ExifCache)
+    decomposed = "photos/Cafe\N{COMBINING ACUTE ACCENT}.ARW"
+    canonical = unicodedata.normalize("NFC", decomposed)
+    cache._cache = {canonical: {"rating": 0}}
+
+    assert cache.dataset_residency([decomposed, canonical, "missing.ARW"]) == (1, 2)
+
+
+def test_cache_near_capacity_uses_configured_limit():
+    cache = ExifCache.__new__(ExifCache)
+    cache._size_limit_bytes = 100
+    cache.volume = Mock(return_value=95)
+
+    assert cache.is_near_capacity() is True
+
+    cache.volume.return_value = 94
+    assert cache.is_near_capacity() is False
+
+
+def test_rating_loader_reports_dataset_eviction(tmp_path, monkeypatch):
+    first = tmp_path / "one.jpg"
+    second = tmp_path / "two.jpg"
+    first.touch()
+    second.touch()
+    paths = [str(first), str(second)]
+    exif_cache = SimpleNamespace(
+        dataset_residency=Mock(return_value=(1, 2)),
+        get_current_size_limit_bytes=Mock(return_value=2 * 1024**3),
+        is_near_capacity=Mock(return_value=True),
+    )
+    state = SimpleNamespace(exif_disk_cache=exif_cache, rating_cache={}, date_cache={})
+    worker = RatingLoaderWorker(
+        [{"path": path} for path in paths],
+        rating_disk_cache=Mock(),
+        app_state=state,
+    )
+    monkeypatch.setattr(
+        "workers.rating_loader_worker.MetadataProcessor.get_batch_display_metadata",
+        lambda *_args: {
+            path: {"rating": 0, "date": None}
+            for path in paths
+        },
+    )
+    warnings = []
+    worker.cache_capacity_warning.connect(lambda *args: warnings.append(args))
+
+    worker.run_load()
+
+    assert warnings == [(2, 1, 2 * 1024**3)]
+
+
+def test_capacity_dialog_is_deferred_until_metadata_load_finishes(monkeypatch):
+    dialog_manager = SimpleNamespace(show_exif_cache_capacity_warning=Mock())
+    status_bar = SimpleNamespace(showMessage=Mock())
+    main_window = SimpleNamespace(
+        dialog_manager=dialog_manager,
+        statusBar=lambda: status_bar,
+        hide_loading_overlay=Mock(),
+        hide_exif_progress=Mock(),
+    )
+    controller = AppController(main_window, Mock(), Mock())
+    monkeypatch.setattr(
+        "ui.app_controller.QTimer.singleShot",
+        lambda _delay, callback: callback(),
+    )
+
+    controller.handle_exif_cache_capacity_warning(4_482, 3_792, 1024**3)
+    assert dialog_manager.show_exif_cache_capacity_warning.call_count == 0
+
+    controller.handle_rating_load_finished()
+
+    dialog_manager.show_exif_cache_capacity_warning.assert_called_once_with(
+        4_482,
+        3_792,
+        1024**3,
+    )


### PR DESCRIPTION
Was culling around 4 thousand photos and loading was getting slow because of the limits in exif data

- Increase default EXIF cache size to 2 GB and set a maximum limit of 5 GB.
- Implement dataset residency tracking in the EXIF cache.
- Add cache capacity warning handling in the AppController and UI.
- Update UI to display EXIF cache progress during metadata loading.
- Introduce tests for EXIF cache defaults and eviction behavior.