### PR TITLE
Feat: Footer shortcut layout

### DIFF
--- a/src/ui/workflow_review_components.py
+++ b/src/ui/workflow_review_components.py
@@ -6,6 +6,7 @@ pages and makes a shortcut's visible label and actual binding share one source
 of truth.
 """
 
+import math
 import sys
 from dataclasses import dataclass
 from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -295,7 +296,7 @@ class WorkflowShortcutStrip(QFrame):
     def __init__(
         self,
         shortcuts: Sequence[WorkflowShortcutSpec],
-        max_columns: int | None = None,
+        max_rows: int = 3,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
@@ -316,8 +317,11 @@ class WorkflowShortcutStrip(QFrame):
         items_layout.setContentsMargins(0, 0, 0, 0)
         items_layout.setHorizontalSpacing(8)
         items_layout.setVerticalSpacing(3)
-        columns = max_columns or max(1, len(shortcuts))
+        columns = max(1, len(shortcuts))
         self._column_limit = columns
+        self._minimum_columns = max(
+            1, math.ceil(len(shortcuts) / max(1, max_rows))
+        )
         self._current_columns = columns
         self._items_layout = items_layout
         self.shortcut_specs = tuple(shortcuts)
@@ -381,6 +385,7 @@ class WorkflowShortcutStrip(QFrame):
             if max(row_widths, default=0) <= available_width:
                 selected_columns = columns
                 break
+        selected_columns = max(selected_columns, self._minimum_columns)
         if selected_columns == self._current_columns:
             return
         self._current_columns = selected_columns

--- a/tests/test_workflow_review_ui.py
+++ b/tests/test_workflow_review_ui.py
@@ -474,7 +474,7 @@ def test_review_workflows_share_compact_review_list_panel():
     assert not pick_best._review_list_panel.filters.isVisible()
 
 
-def test_footer_shortcuts_use_the_most_columns_that_fit():
+def test_footer_shortcuts_use_at_most_three_rows_and_still_reflow():
     strip = WorkflowShortcutStrip(ORGANIZE_SHORTCUTS)
     stylesheet = Path("src/ui/dark_theme.qss").read_text(encoding="utf-8")
     strip.setStyleSheet(stylesheet)
@@ -487,7 +487,11 @@ def test_footer_shortcuts_use_the_most_columns_that_fit():
     strip.resize(320, 100)
     _app.processEvents()
 
-    assert 1 < strip._current_columns < len(ORGANIZE_SHORTCUTS)
+    row_count = (
+        len(ORGANIZE_SHORTCUTS) + strip._current_columns - 1
+    ) // strip._current_columns
+    assert strip._current_columns < len(ORGANIZE_SHORTCUTS)
+    assert row_count <= 3
 
 
 def test_organize_top_bar_returns_to_a_single_control_row():


### PR DESCRIPTION
The shortcuts layout was occupying too much height if the window was small and it was loading exif data and previews