### PR TITLE
refactor: steps easy delete fix rotation now need confirmation before proceeding

### DIFF
--- a/assets/keyboard-layout.html
+++ b/assets/keyboard-layout.html
@@ -912,7 +912,7 @@ ol{
             <div data-key="KeyQ" class="key">Q<span class="userText"></span></div>
             <div data-key="KeyW" class="key">W<span class="userText"></span></div>
             <div data-key="KeyE" class="key">E<span class="userText"></span></div>
-            <div data-key="KeyR" class="key">R<span class="userText"></span></div>
+            <div data-key="KeyR" class="key key--colour--orange">R<span class="userText">R · Reset current · Shift+R · Reset all</span></div>
             <div data-key="KeyT" class="key">T<span class="userText"></span></div>
             <div data-key="KeyY" class="key">Y<span class="userText"></span></div>
             <div data-key="KeyU" class="key">U<span class="userText"></span></div>
@@ -1070,10 +1070,10 @@ ol{
 
           <div class="keyboard__row keyboard__row--lg">
             <div data-key="Tab" class="key key--3">TAB<span class="userText"></span></div>
-            <div data-key="KeyQ" class="key">Q<span class="userText"></span></div>
+            <div data-key="KeyQ" class="key key--colour--orange">Q<span class="userText">Q · −90° override</span></div>
             <div data-key="KeyW" class="key">W<span class="userText"></span></div>
-            <div data-key="KeyE" class="key">E<span class="userText"></span></div>
-            <div data-key="KeyR" class="key key--colour--orange">R<span class="userText">1 · R −90° · Shift+R +90° override</span></div>
+            <div data-key="KeyE" class="key key--colour--orange">E<span class="userText">E · +90° override</span></div>
+            <div data-key="KeyR" class="key key--colour--orange">R<span class="userText">R · Reset current · Shift+R · Reset all</span></div>
             <div data-key="KeyT" class="key">T<span class="userText"></span></div>
             <div data-key="KeyY" class="key">Y<span class="userText"></span></div>
             <div data-key="KeyU" class="key">U<span class="userText"></span></div>
@@ -1234,7 +1234,7 @@ ol{
             <div data-key="KeyQ" class="key">Q<span class="userText"></span></div>
             <div data-key="KeyW" class="key">W<span class="userText"></span></div>
             <div data-key="KeyE" class="key">E<span class="userText"></span></div>
-            <div data-key="KeyR" class="key">R<span class="userText"></span></div>
+            <div data-key="KeyR" class="key key--colour--orange">R<span class="userText">R · Reset current · Shift+R · Reset all</span></div>
             <div data-key="KeyT" class="key">T<span class="userText"></span></div>
             <div data-key="KeyY" class="key">Y<span class="userText"></span></div>
             <div data-key="KeyU" class="key">U<span class="userText"></span></div>

--- a/src/ui/advanced_image_viewer.py
+++ b/src/ui/advanced_image_viewer.py
@@ -1070,13 +1070,6 @@ class IndividualViewer(QWidget):
         """Handle mouse press events to show context menu on right-click."""
         if event.button() == Qt.MouseButton.RightButton and self._file_path is not None:
             self._show_context_menu(event.pos())
-        elif (
-            event.button() == Qt.MouseButton.LeftButton
-            and self._file_path is not None
-            and self._media_type != "video"
-        ):
-            self.clicked.emit(self._file_path)
-            super().mousePressEvent(event)
         else:
             super().mousePressEvent(event)
 

--- a/src/ui/app_state.py
+++ b/src/ui/app_state.py
@@ -352,6 +352,30 @@ class AppState:
         logger.info(f"Unmarking file for deletion: {os.path.basename(file_path)}")
         self.marked_for_deletion.discard(file_path)
 
+    def set_deletion_marks(self, mark_state: dict[str, bool]) -> int:
+        """Apply many deletion marks atomically without per-path logging."""
+
+        to_mark = {
+            path
+            for path, marked in mark_state.items()
+            if marked and path not in self.marked_for_deletion
+        }
+        to_unmark = {
+            path
+            for path, marked in mark_state.items()
+            if not marked and path in self.marked_for_deletion
+        }
+        self.marked_for_deletion.update(to_mark)
+        self.marked_for_deletion.difference_update(to_unmark)
+        changed = len(to_mark) + len(to_unmark)
+        if changed:
+            logger.info(
+                "Updated deletion marks in bulk: %d marked, %d unmarked",
+                len(to_mark),
+                len(to_unmark),
+            )
+        return changed
+
     def is_marked_for_deletion(self, file_path: str) -> bool:
         """Checks if a file is marked for deletion."""
 

--- a/src/ui/controllers/active_image_controller.py
+++ b/src/ui/controllers/active_image_controller.py
@@ -37,6 +37,15 @@ class ActiveImageController:
 
         if self._syncing:
             return False
+        active_workflow = getattr(self._context.app_state, "workflow_step", None)
+        if source != active_workflow:
+            adapter = self._context.get_active_image_adapter(active_workflow)
+            has_changes = getattr(adapter, "has_unconfirmed_changes", None)
+            if callable(has_changes) and has_changes():
+                show_required = getattr(adapter, "show_confirm_or_reset_required", None)
+                if callable(show_required):
+                    show_required()
+                return False
         normalized = str(path) if path else None
         changed = normalized != self.active_path
         self._context.app_state.focused_image_path = normalized

--- a/src/ui/controllers/deletion_mark_controller.py
+++ b/src/ui/controllers/deletion_mark_controller.py
@@ -3,7 +3,7 @@ import os
 from collections.abc import Callable, Iterable
 from PyQt6.QtGui import QStandardItem, QColor
 from PyQt6.QtWidgets import QApplication
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import QModelIndex, Qt
 
 from ui.helpers.deletion_utils import build_presentation
 
@@ -179,6 +179,69 @@ class DeletionMarkController:
             )
             self._update_item_presentation(item, p, is_blurred)
         return count
+
+    def set_paths_marked(
+        self,
+        mark_state: dict[str, bool],
+        file_system_model,
+        proxy_model,
+    ) -> int:
+        """Apply a complete mark map with one model traversal.
+
+        Bulk review actions can touch hundreds of photos. Looking up every path
+        by independently walking the proxy model makes that work quadratic and
+        blocks the UI. Update application state first, then refresh matching
+        model items during one breadth-first pass.
+        """
+
+        normalized = {
+            path: bool(marked)
+            for path, marked in mark_state.items()
+            if isinstance(path, str) and path
+        }
+        bulk_setter = getattr(self.app_state, "set_deletion_marks", None)
+        if callable(bulk_setter):
+            changed = bulk_setter(normalized)
+        else:
+            changed = 0
+            for path, marked in normalized.items():
+                if marked == self._is_marked_func(path):
+                    continue
+                if marked:
+                    self.app_state.mark_for_deletion(path)
+                else:
+                    self.app_state.unmark_for_deletion(path)
+                changed += 1
+
+        if not normalized:
+            return changed
+
+        queue = [
+            proxy_model.index(row, 0, QModelIndex())
+            for row in range(proxy_model.rowCount(QModelIndex()))
+        ]
+        head = 0
+        while head < len(queue):
+            proxy_index = queue[head]
+            head += 1
+            if not proxy_index.isValid():
+                continue
+            source_index = proxy_model.mapToSource(proxy_index)
+            item = file_system_model.itemFromIndex(source_index)
+            if item is not None:
+                data = item.data(Qt.ItemDataRole.UserRole)
+                path = data.get("path") if isinstance(data, dict) else None
+                if path in normalized:
+                    self._update_item_presentation(
+                        item,
+                        path,
+                        data.get("is_blurred"),
+                    )
+            queue.extend(
+                proxy_model.index(row, 0, proxy_index)
+                for row in range(proxy_model.rowCount(proxy_index))
+            )
+        return changed
 
     def mark_others_in_collection(
         self,

--- a/src/ui/dark_theme.qss
+++ b/src/ui/dark_theme.qss
@@ -606,6 +606,90 @@ QFrame#dialogCard {
     padding: 4px;
 }
 
+/* Confirm-or-reset review guard */
+QDialog#confirmOrResetDialog {
+    background: #272A2D;
+    border: 1px solid #4A5158;
+    border-radius: 14px;
+}
+
+QLabel#confirmOrResetEyebrow {
+    background: transparent;
+    color: #73A7E8;
+    font-size: 8.5pt;
+    font-weight: bold;
+    letter-spacing: 1.5px;
+}
+
+QLabel#confirmOrResetTitle {
+    background: transparent;
+    color: #F2F5F7;
+    font-size: 18pt;
+    font-weight: bold;
+}
+
+QLabel#confirmOrResetMessage {
+    background: transparent;
+    color: #C5CFD8;
+    font-size: 11pt;
+    padding-bottom: 2px;
+}
+
+QFrame#confirmOrResetExplanation {
+    background: #202326;
+    border: 1px solid #3E454B;
+    border-radius: 9px;
+}
+
+QLabel#confirmOrResetOption {
+    background: transparent;
+    color: #B8C3CC;
+    font-size: 10pt;
+}
+
+QLabel#confirmOrResetHint {
+    background: transparent;
+    color: #8D9AA5;
+    font-size: 9pt;
+}
+
+QPushButton#confirmOrResetResetButton {
+    background: #353A3E;
+    color: #D1D8DE;
+    border: 1px solid #515A61;
+    border-radius: 8px;
+    padding: 10px 18px;
+    min-width: 145px;
+    font-weight: 600;
+}
+
+QPushButton#confirmOrResetResetButton:hover {
+    background: #41474C;
+    border-color: #69747C;
+    color: #FFFFFF;
+}
+
+QPushButton#confirmOrResetConfirmButton {
+    background: #3569B8;
+    color: #FFFFFF;
+    border: 1px solid #4A7BC5;
+    border-radius: 8px;
+    padding: 10px 20px;
+    min-width: 145px;
+    font-weight: bold;
+}
+
+QPushButton#confirmOrResetConfirmButton:hover {
+    background: #4177C7;
+    border-color: #6090D3;
+}
+
+QPushButton#confirmOrResetConfirmButton:pressed,
+QPushButton#confirmOrResetResetButton:pressed {
+    padding-top: 11px;
+    padding-bottom: 9px;
+}
+
 /* Card Section Title */
 QLabel#cardSectionTitle {
     color: #A9B7C6;

--- a/src/ui/dialog_manager.py
+++ b/src/ui/dialog_manager.py
@@ -1250,9 +1250,7 @@ class DialogManager:
         white_threshold_spin.setDecimals(1)
         white_threshold_spin.setSingleStep(1.0)
         white_threshold_spin.setValue(get_easy_delete_white_threshold())
-        white_threshold_spin.setToolTip(
-            "Brightness limit to flag overexposed photos."
-        )
+        white_threshold_spin.setToolTip("Brightness limit to flag overexposed photos.")
         easy_delete_form.addWidget(white_threshold_label, 2, 0)
         easy_delete_form.addWidget(white_threshold_spin, 2, 1)
 

--- a/src/ui/easy_delete_step_widget.py
+++ b/src/ui/easy_delete_step_widget.py
@@ -24,6 +24,7 @@ from ui.workflow_review_components import (
     WorkflowReviewListPanel,
     WorkflowStateBanner,
     install_workflow_shortcuts,
+    show_confirm_or_reset_notice,
 )
 from ui.workflow_metadata import build_workflow_metadata_rows
 from ui.advanced_image_viewer import SynchronizedImageViewer
@@ -63,6 +64,7 @@ class EasyDeleteStepWidget(QWidget):
     skip_requested = pyqtSignal()
     mark_for_deletion_requested = pyqtSignal(list)
     unmark_for_deletion_requested = pyqtSignal(list)
+    deletion_state_requested = pyqtSignal(dict)
     active_image_changed = pyqtSignal(str)
 
     def __init__(self, parent: QWidget | None = None) -> None:
@@ -82,6 +84,7 @@ class EasyDeleteStepWidget(QWidget):
         self._has_any_marked_func: Callable[[], bool] | None = None
         self._pending_keep_by_review: dict[str, dict[str, bool]] = {}
         self._confirmed_reviews: set[str] = set()
+        self._confirmation_order: list[str] = []
         self._marks_before_confirmation: dict[str, set[str]] = {}
         self._publishing_confirmation = False
         self._info_visible = False
@@ -101,6 +104,8 @@ class EasyDeleteStepWidget(QWidget):
                 "previous": self._on_prev,
                 "next": self._on_next,
                 "confirm": self._on_confirm,
+                "reset": self.reset_current_to_default,
+                "reset_all": self.reset_all_to_default,
                 "apply": self._on_apply,
                 "apply_all": self._on_apply_all,
                 "info": self._toggle_info,
@@ -133,9 +138,78 @@ class EasyDeleteStepWidget(QWidget):
         """Forget local review confirmations after shared Trash marks are cleared."""
         self._pending_keep_by_review.clear()
         self._confirmed_reviews.clear()
+        self._confirmation_order.clear()
         self._marks_before_confirmation.clear()
         if hasattr(self, "_items_list"):
             self._refresh_controls()
+
+    def has_unconfirmed_changes(self) -> bool:
+        if self._current_index < 0 or not self._flagged_paths:
+            return False
+        review_path = self._flagged_paths[self._current_index]
+        if review_path in self._confirmed_reviews:
+            return False
+        entry = self._results.get(review_path, {})
+        return self._pending_keep_state(review_path, entry) != self._default_keep_state(
+            review_path, entry
+        )
+
+    def show_confirm_or_reset_required(self) -> None:
+        show_confirm_or_reset_notice(
+            self,
+            confirm=self._on_confirm,
+            reset=self.reset_current_to_default,
+            reset_all=self.reset_all_to_default,
+        )
+
+    def reset_current_to_default(self) -> None:
+        if self._current_index < 0 or not self._flagged_paths:
+            return
+        review_path = self._flagged_paths[self._current_index]
+        entry = self._results.get(review_path, {})
+        candidates = self._review_candidates(review_path, entry)
+        if review_path in self._confirmed_reviews:
+            self._cancel_confirmation(review_path, candidates, refresh=False)
+        self._pending_keep_by_review[review_path] = self._default_keep_state(
+            review_path, entry
+        )
+        self._refresh_controls()
+
+    def reset_all_to_default(self) -> None:
+        """Unconfirm every review and restore all detector suggestions."""
+
+        restored_mark_state: dict[str, bool] = {}
+        ordered_confirmations = list(reversed(self._confirmation_order))
+        ordered_confirmations.extend(
+            review_path
+            for review_path in self._confirmed_reviews
+            if review_path not in self._confirmation_order
+        )
+        for review_path in ordered_confirmations:
+            entry = self._results.get(review_path, {})
+            prior_marks = self._marks_before_confirmation.get(review_path, set())
+            restored_mark_state.update(
+                {
+                    candidate: candidate in prior_marks
+                    for candidate in self._review_candidates(review_path, entry)
+                }
+            )
+        self._confirmed_reviews.clear()
+        self._confirmation_order.clear()
+        self._marks_before_confirmation.clear()
+        for review_path, entry in self._results.items():
+            self._pending_keep_by_review[review_path] = self._default_keep_state(
+                review_path, entry
+            )
+        if restored_mark_state:
+            self._publish_mark_state(restored_mark_state)
+        self._refresh_controls()
+
+    def _allow_review_departure(self) -> bool:
+        if not self.has_unconfirmed_changes():
+            return True
+        self.show_confirm_or_reset_required()
+        return False
 
     def _discard_stale_confirmations(self) -> None:
         if self._publishing_confirmation or not self._is_marked_func:
@@ -151,6 +225,8 @@ class EasyDeleteStepWidget(QWidget):
             )
             if not matches_shared_state:
                 self._confirmed_reviews.discard(review_path)
+                if review_path in self._confirmation_order:
+                    self._confirmation_order.remove(review_path)
                 self._marks_before_confirmation.pop(review_path, None)
 
     # ------------------------------------------------------------------
@@ -185,6 +261,7 @@ class EasyDeleteStepWidget(QWidget):
             return
         self._pending_keep_by_review.clear()
         self._confirmed_reviews.clear()
+        self._confirmation_order.clear()
         self._marks_before_confirmation.clear()
         self._metadata_cache.clear()
         # Keep a value snapshot. AppState owns and mutates the live result mapping
@@ -388,6 +465,8 @@ class EasyDeleteStepWidget(QWidget):
         if not self._flagged_paths:
             return
         index = max(0, min(index, len(self._flagged_paths) - 1))
+        if index != self._current_index and not self._allow_review_departure():
+            return
         self._current_index = index
         review_path = self._flagged_paths[index]
         pair_path = self._results.get(review_path, {}).get("pair_path")
@@ -410,6 +489,8 @@ class EasyDeleteStepWidget(QWidget):
             pair_path = self._results.get(review_path, {}).get("pair_path")
             if path not in {review_path, pair_path}:
                 continue
+            if index != self._current_index and not self._allow_review_departure():
+                return False
             self._focused_path = path
             self._syncing_active_image = True
             try:
@@ -476,7 +557,13 @@ class EasyDeleteStepWidget(QWidget):
         confirmed = path in self._confirmed_reviews
         candidates = self._review_candidates(path, entry)
         kept_count = sum(keep_by_path.get(candidate, True) for candidate in candidates)
-        if confirmed:
+        if self.has_unconfirmed_changes():
+            self._state_banner.set_state(
+                "Set each photo, then confirm",
+                "Your Keep/Trash changes are local until you press Confirm.",
+                tone="warning",
+            )
+        elif confirmed:
             self._state_banner.set_state(
                 "Decisions confirmed",
                 (
@@ -547,17 +634,11 @@ class EasyDeleteStepWidget(QWidget):
         slot: int,
     ) -> None:
         if selected_for_delete:
-            state = (
-                "MARKED FOR TRASH · staged"
-                if confirmed
-                else "SELECTED FOR TRASH · not confirmed"
-            )
+            state = "TRASH"
             color = "#FF7B86"
             border = "#E53935"
         else:
-            state = (
-                "KEEP · unmarked" if confirmed else "SELECTED TO KEEP · not confirmed"
-            )
+            state = "KEEP"
             color = "#66BB6A"
             border = "#2E7D32"
         state_label.setText(state)
@@ -687,15 +768,19 @@ class EasyDeleteStepWidget(QWidget):
             self._prev_btn.setEnabled(False)
             self._next_btn.setEnabled(False)
             self._confirm_btn.setEnabled(False)
+            self._reset_btn.setEnabled(False)
             self._apply_all_btn.setEnabled(False)
             return
         self._confirm_btn.setEnabled(True)
+        path = self._flagged_paths[self._current_index]
+        self._reset_btn.setEnabled(
+            self.has_unconfirmed_changes() or path in self._confirmed_reviews
+        )
         self._apply_all_btn.setEnabled(True)
         self._counter_label.setText(f"{self._current_index + 1} of {total}")
         self._prev_btn.setEnabled(self._current_index > 0)
         self._next_btn.setEnabled(self._current_index < total - 1)
 
-        path = self._flagged_paths[self._current_index]
         self._confirm_btn.setText(
             "Cancel confirmation" if path in self._confirmed_reviews else "Confirm  →"
         )
@@ -712,6 +797,13 @@ class EasyDeleteStepWidget(QWidget):
         if not path:
             return
         index = self._flagged_paths.index(path)
+        if index != self._current_index and not self._allow_review_departure():
+            self._items_list.blockSignals(True)
+            self._items_list.setCurrentRow(
+                self._list_row_by_path[self._flagged_paths[self._current_index]]
+            )
+            self._items_list.blockSignals(False)
+            return
         if index != self._current_index:
             self._navigate_to(index)
 
@@ -778,6 +870,13 @@ class EasyDeleteStepWidget(QWidget):
         self._refresh_controls()
 
     def _publish_mark_state(self, mark_state: dict[str, bool]) -> None:
+        if self.receivers(self.deletion_state_requested):
+            self._publishing_confirmation = True
+            try:
+                self.deletion_state_requested.emit(mark_state)
+            finally:
+                self._publishing_confirmation = False
+            return
         to_mark = [
             path
             for path, marked in mark_state.items()
@@ -820,6 +919,7 @@ class EasyDeleteStepWidget(QWidget):
             }
         )
         self._confirmed_reviews.add(review_path)
+        self._confirmation_order.append(review_path)
         next_index = next(
             (
                 i
@@ -840,6 +940,8 @@ class EasyDeleteStepWidget(QWidget):
 
         prior_marks = self._marks_before_confirmation.pop(review_path, set())
         self._confirmed_reviews.discard(review_path)
+        if review_path in self._confirmation_order:
+            self._confirmation_order.remove(review_path)
         self._publish_mark_state(
             {candidate: candidate in prior_marks for candidate in candidates}
         )
@@ -847,6 +949,8 @@ class EasyDeleteStepWidget(QWidget):
             self._refresh_controls()
 
     def _on_apply_all(self) -> None:
+        if not self._allow_review_departure():
+            return
         desired_mark_state: dict[str, bool] = {}
         for review_path in self._flagged_paths:
             entry = self._results.get(review_path, {})
@@ -866,11 +970,22 @@ class EasyDeleteStepWidget(QWidget):
                 }
             )
             self._confirmed_reviews.add(review_path)
+            if review_path not in self._confirmation_order:
+                self._confirmation_order.append(review_path)
         self._publish_mark_state(desired_mark_state)
         self._refresh_controls()
 
     def _on_category_toggled(self, category: str, checked: bool) -> None:
         if self._updating_category_toggles:
+            return
+        if not self._allow_review_departure():
+            self._updating_category_toggles = True
+            try:
+                self._category_checkboxes[category].setChecked(
+                    self._enabled_categories.get(category, False)
+                )
+            finally:
+                self._updating_category_toggles = False
             return
         self._enabled_categories[category] = checked
         self._apply_category_filter()
@@ -914,6 +1029,8 @@ class EasyDeleteStepWidget(QWidget):
         self._sync_viewer.clear()
 
     def _on_apply(self) -> None:
+        if not self._allow_review_departure():
+            return
         self.apply_requested.emit()
 
     def _on_skip(self) -> None:
@@ -1080,6 +1197,13 @@ class EasyDeleteStepWidget(QWidget):
         self._confirm_btn.setMinimumWidth(110)
         self._confirm_btn.clicked.connect(self._on_confirm)
 
+        self._reset_btn = QPushButton("Reset default")
+        self._reset_btn.setObjectName("workflowGhostButton")
+        self._reset_btn.setToolTip(
+            "Reset this review (R), or reset every review (Shift+R)"
+        )
+        self._reset_btn.clicked.connect(self.reset_current_to_default)
+
         self._apply_btn = QPushButton("Apply")
         self._apply_btn.setObjectName("workflowPrimaryButton")
         self._apply_btn.setToolTip(
@@ -1091,6 +1215,7 @@ class EasyDeleteStepWidget(QWidget):
         action.addWidget(self._counter_label)
         action.addWidget(self._next_btn)
         action.addWidget(self._confirm_btn)
+        action.addWidget(self._reset_btn)
         action.addStretch()
         action.addWidget(self._apply_btn)
         right_layout.addLayout(action)

--- a/src/ui/fix_rotation_step_widget.py
+++ b/src/ui/fix_rotation_step_widget.py
@@ -24,6 +24,7 @@ from ui.workflow_review_components import (
     WorkflowReviewListPanel,
     WorkflowStateBanner,
     install_workflow_shortcuts,
+    show_confirm_or_reset_notice,
 )
 
 logger = logging.getLogger(__name__)
@@ -83,6 +84,8 @@ class FixRotationStepWidget(QWidget):
                 "previous": self._on_prev,
                 "next": self._on_next,
                 "primary": self._on_confirm,
+                "reset": self.reset_current_to_default,
+                "reset_all": self.reset_all_to_default,
                 "apply": self._on_apply,
             },
         )
@@ -110,6 +113,49 @@ class FixRotationStepWidget(QWidget):
         if self._ordered_paths and self._current_index >= 0:
             self._show_current()
         self._refresh_controls()
+
+    def has_unconfirmed_changes(self) -> bool:
+        if self._current_index < 0 or not self._ordered_paths:
+            return False
+        path = self._ordered_paths[self._current_index]
+        if path in self._confirmed:
+            return False
+        return not self._marked.get(path, False) or path in self._angle_overrides
+
+    def show_confirm_or_reset_required(self) -> None:
+        show_confirm_or_reset_notice(
+            self,
+            confirm=self._on_confirm,
+            reset=self.reset_current_to_default,
+            reset_all=self.reset_all_to_default,
+        )
+
+    def reset_current_to_default(self) -> None:
+        if self._current_index < 0 or not self._ordered_paths:
+            return
+        path = self._ordered_paths[self._current_index]
+        self._confirmed.discard(path)
+        self._angle_overrides.pop(path, None)
+        self._marked[path] = True
+        self._show_current()
+        self._refresh_controls()
+
+    def reset_all_to_default(self) -> None:
+        """Unconfirm every image and restore all suggested rotations."""
+
+        self._confirmed.clear()
+        self._angle_overrides.clear()
+        for path in self._ordered_paths:
+            self._marked[path] = True
+        if self._current_index >= 0:
+            self._show_current()
+        self._refresh_controls()
+
+    def _allow_review_departure(self) -> bool:
+        if not self.has_unconfirmed_changes():
+            return True
+        self.show_confirm_or_reset_required()
+        return False
 
     def apply_pending_rotations(self) -> None:
         """Apply the current queue through the widget's normal state machine."""
@@ -319,6 +365,8 @@ class FixRotationStepWidget(QWidget):
         if not self._ordered_paths:
             return
         index = max(0, min(index, len(self._ordered_paths) - 1))
+        if index != self._current_index and not self._allow_review_departure():
+            return
         self._current_index = index
 
         self._items_list.blockSignals(True)
@@ -336,6 +384,8 @@ class FixRotationStepWidget(QWidget):
         try:
             index = self._ordered_paths.index(path)
         except ValueError:
+            return False
+        if index != self._current_index and not self._allow_review_departure():
             return False
         self._syncing_active_image = True
         try:
@@ -395,7 +445,13 @@ class FixRotationStepWidget(QWidget):
         else:
             self._preview_hdr.setText("ROTATED PREVIEW · not selected")
 
-        if not confirmed:
+        if self.has_unconfirmed_changes():
+            self._state_banner.set_state(
+                "Choose, then confirm",
+                "Your rotation change is only a preview until you press Confirm.",
+                tone="warning",
+            )
+        elif not confirmed:
             self._state_banner.set_state(
                 "Choose, then confirm",
                 "This is only a preview selection. Nothing is queued until you press Confirm.",
@@ -457,6 +513,9 @@ class FixRotationStepWidget(QWidget):
         self._confirm_btn.setText(
             "Cancel confirmation" if path in self._confirmed else "Confirm  →"
         )
+        self._reset_btn.setEnabled(
+            self.has_unconfirmed_changes() or path in self._confirmed
+        )
 
         self._refresh_apply_button()
         self._refresh_list_colors()
@@ -480,6 +539,11 @@ class FixRotationStepWidget(QWidget):
 
     def _on_item_clicked(self, item: QListWidgetItem) -> None:
         row = self._items_list.row(item)
+        if row != self._current_index and not self._allow_review_departure():
+            self._items_list.blockSignals(True)
+            self._items_list.setCurrentRow(self._current_index)
+            self._items_list.blockSignals(False)
+            return
         if row != self._current_index:
             self._navigate_to(row)
 
@@ -533,6 +597,8 @@ class FixRotationStepWidget(QWidget):
         self._rotate_current_preview(90)
 
     def _on_confirm_all(self) -> None:
+        if not self._allow_review_departure():
+            return
         for path in self._ordered_paths:
             if self._selected_angle(path) == 0:
                 self._angle_overrides.pop(path, None)
@@ -568,6 +634,8 @@ class FixRotationStepWidget(QWidget):
             self._navigate_to(next_index)
 
     def _on_apply(self) -> None:
+        if not self._allow_review_departure():
+            return
         rotations = self.pending_rotations()
         if rotations:
             self._submitted_paths = set(rotations)
@@ -811,7 +879,14 @@ class FixRotationStepWidget(QWidget):
         self._confirm_btn.setMinimumWidth(110)
         self._confirm_btn.clicked.connect(self._on_confirm)
 
-        self._rotate_counterclockwise_btn = QPushButton("Rotate −90°  [R]")
+        self._reset_btn = QPushButton("Reset default")
+        self._reset_btn.setObjectName("workflowGhostButton")
+        self._reset_btn.setToolTip(
+            "Reset this rotation (R), or reset every rotation (Shift+R)"
+        )
+        self._reset_btn.clicked.connect(self.reset_current_to_default)
+
+        self._rotate_counterclockwise_btn = QPushButton("Rotate −90°  [Q]")
         self._rotate_counterclockwise_btn.setObjectName("workflowGhostButton")
         self._rotate_counterclockwise_btn.setToolTip(
             "Override the suggestion and rotate the preview 90° counterclockwise"
@@ -820,7 +895,7 @@ class FixRotationStepWidget(QWidget):
             self._on_rotate_counterclockwise
         )
 
-        self._rotate_clockwise_btn = QPushButton("Rotate +90°  [Shift+R]")
+        self._rotate_clockwise_btn = QPushButton("Rotate +90°  [E]")
         self._rotate_clockwise_btn.setObjectName("workflowGhostButton")
         self._rotate_clockwise_btn.setToolTip(
             "Override the suggestion and rotate the preview 90° clockwise"
@@ -836,6 +911,7 @@ class FixRotationStepWidget(QWidget):
         action.addWidget(self._counter_label)
         action.addWidget(self._next_btn)
         action.addWidget(self._confirm_btn)
+        action.addWidget(self._reset_btn)
         action.addWidget(self._rotate_counterclockwise_btn)
         action.addWidget(self._rotate_clockwise_btn)
         action.addStretch(1)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -922,6 +922,22 @@ class MainWindow(QMainWindow):
             trash_paths=self.app_state.get_marked_files(),
         )
 
+    def _has_blocking_review_edit(self, workflow_step: str) -> bool:
+        adapter_getter = getattr(self, "get_active_image_adapter", None)
+        if not callable(adapter_getter):
+            return False
+        widget = adapter_getter(workflow_step)
+        has_changes = getattr(widget, "has_unconfirmed_changes", None)
+        if not callable(has_changes) or not has_changes():
+            return False
+        show_required = getattr(widget, "show_confirm_or_reset_required", None)
+        if callable(show_required):
+            show_required()
+        refresh_navigation = getattr(self, "update_workflow_navigation", None)
+        if callable(refresh_navigation):
+            refresh_navigation()
+        return True
+
     def _request_workflow_transition(self, destination: str | None) -> None:
         source = self.app_state.workflow_step
         switching = destination is not None
@@ -937,6 +953,9 @@ class MainWindow(QMainWindow):
                 4000,
             )
             self.update_workflow_navigation()
+            return
+
+        if MainWindow._has_blocking_review_edit(self, source):
             return
 
         pending = self._collect_workflow_pending_state(source)
@@ -1645,6 +1664,7 @@ class MainWindow(QMainWindow):
             widget.unmark_for_deletion_requested.connect(
                 self._unmark_paths_for_deletion
             )
+            widget.deletion_state_requested.connect(self._set_paths_deletion_state)
             widget.active_image_changed.connect(
                 lambda path: self.active_image_controller.publish(
                     path, source="easy_delete"
@@ -1691,6 +1711,7 @@ class MainWindow(QMainWindow):
             widget.unmark_for_deletion_requested.connect(
                 self._unmark_paths_for_deletion
             )
+            widget.deletion_state_requested.connect(self._set_paths_deletion_state)
             widget.active_image_changed.connect(
                 lambda path: self.active_image_controller.publish(
                     path, source="pick_best"
@@ -1908,6 +1929,24 @@ class MainWindow(QMainWindow):
             self.proxy_model,
         )
         self.proxy_model.invalidate()
+        self._refresh_workflow_deletion_state()
+
+    def _set_paths_deletion_state(self, mark_state: dict[str, bool]) -> None:
+        """Apply a bulk review decision with one model pass and one UI refresh."""
+
+        active_view = self._get_active_file_view()
+        active_model = active_view.model() if active_view is not None else None
+        proxy_model = (
+            active_model
+            if isinstance(active_model, QSortFilterProxyModel)
+            else self.proxy_model
+        )
+        self.deletion_controller.set_paths_marked(
+            mark_state,
+            self.file_system_model,
+            proxy_model,
+        )
+        proxy_model.invalidate()
         self._refresh_workflow_deletion_state()
 
     def update_grouping_preview(self, text: str) -> None:

--- a/src/ui/pick_best_step_widget.py
+++ b/src/ui/pick_best_step_widget.py
@@ -34,6 +34,7 @@ from ui.workflow_review_components import (
     WorkflowReviewListPanel,
     WorkflowStateBanner,
     install_workflow_shortcuts,
+    show_confirm_or_reset_notice,
 )
 from ui.workflow_metadata import build_workflow_metadata_rows
 
@@ -168,6 +169,7 @@ class TournamentGroup:
     paths: list[str]
     ai_pick: str
     keep_by_path: dict[str, bool]
+    default_keep_by_path: dict[str, bool]
     advancing_path: str
     confirmed: bool = False
 
@@ -214,6 +216,7 @@ class PickBestStepWidget(QWidget):
     apply_requested = pyqtSignal()
     mark_for_deletion_requested = pyqtSignal(list)
     unmark_for_deletion_requested = pyqtSignal(list)
+    deletion_state_requested = pyqtSignal(dict)
     active_image_changed = pyqtSignal(str)
 
     def __init__(self, parent: QWidget | None = None) -> None:
@@ -241,6 +244,48 @@ class PickBestStepWidget(QWidget):
         self._create_widgets()
         self._connect_signals()
         self._create_shortcuts()
+
+    def has_unconfirmed_changes(self) -> bool:
+        if not self._tournaments:
+            return False
+        group = self._current_group()
+        if group.confirmed:
+            return False
+        return group.keep_by_path != group.default_keep_by_path
+
+    def show_confirm_or_reset_required(self) -> None:
+        show_confirm_or_reset_notice(
+            self,
+            confirm=self._on_confirm,
+            reset=self.reset_current_to_default,
+            reset_all=self.reset_all_to_default,
+        )
+
+    def reset_current_to_default(self) -> None:
+        if not self._tournaments:
+            return
+        tournament = self._current_tournament()
+        group = self._current_group()
+        if group.confirmed or tournament.finalized:
+            self._invalidate_later_rounds(tournament)
+            group.confirmed = False
+        group.keep_by_path = dict(group.default_keep_by_path)
+        group.advancing_path = self._resolve_advancing_path(
+            group.paths, group.keep_by_path, group.ai_pick
+        )
+        self._refresh_photo_list()
+        self._show_current_group()
+
+    def reset_all_to_default(self) -> None:
+        """Unconfirm all comparisons and rebuild their immutable defaults."""
+
+        self.discard_pending_decisions()
+
+    def _allow_review_departure(self) -> bool:
+        if not self.has_unconfirmed_changes():
+            return True
+        self.show_confirm_or_reset_required()
+        return False
 
     def show_loading(self, message: str = "Analysing…", percent: int = 0) -> None:
         self._stack.setCurrentWidget(self._page_loading)
@@ -311,9 +356,12 @@ class PickBestStepWidget(QWidget):
 
     def discard_pending_decisions(self) -> None:
         """Reset every local tournament while retaining worker analysis results."""
+        restored_mark_state: dict[str, bool] = {}
         for tournament in self._tournaments:
             if tournament.prior_marks is not None:
-                self._publish_confirmed_state(dict(tournament.prior_marks))
+                restored_mark_state.update(tournament.prior_marks)
+        if restored_mark_state:
+            self._publish_confirmed_state(restored_mark_state)
         self._tournaments = [
             self._build_tournament(key, payload)
             for key, payload in zip(self._cluster_keys, self._clusters, strict=True)
@@ -464,6 +512,13 @@ class PickBestStepWidget(QWidget):
         self._confirm_btn.setObjectName("workflowPrimaryButton")
         action_layout.addWidget(self._confirm_btn)
 
+        self._reset_btn = QPushButton("Reset default")
+        self._reset_btn.setObjectName("workflowGhostButton")
+        self._reset_btn.setToolTip(
+            "Reset this comparison (R), or reset every comparison (Shift+R)"
+        )
+        action_layout.addWidget(self._reset_btn)
+
         self._keep_all_btn = QPushButton("Keep all")
         self._keep_all_btn.setObjectName("workflowGhostButton")
         self._keep_all_btn.setToolTip(
@@ -485,6 +540,7 @@ class PickBestStepWidget(QWidget):
     def _connect_signals(self) -> None:
         self._done_btn.clicked.connect(self._on_apply)
         self._confirm_btn.clicked.connect(self._on_confirm)
+        self._reset_btn.clicked.connect(self.reset_current_to_default)
         self._keep_all_btn.clicked.connect(self._on_keep_all)
         self._items_list.itemClicked.connect(self._on_photo_item_clicked)
         self._prev_cluster_btn.clicked.connect(self._prev_cluster)
@@ -515,6 +571,8 @@ class PickBestStepWidget(QWidget):
                 "info": self._toggle_info,
                 "keep_all": self._on_keep_all,
                 "confirm": self._on_confirm,
+                "reset": self.reset_current_to_default,
+                "reset_all": self.reset_all_to_default,
                 "apply": self._on_apply,
             },
         )
@@ -544,6 +602,7 @@ class PickBestStepWidget(QWidget):
                     paths=list(paths),
                     ai_pick=ai_pick,
                     keep_by_path=keep_by_path,
+                    default_keep_by_path=dict(keep_by_path),
                     advancing_path=self._resolve_advancing_path(
                         paths, keep_by_path, ai_pick
                     ),
@@ -765,6 +824,9 @@ class PickBestStepWidget(QWidget):
         )
 
     def _on_photo_item_clicked(self, item: QListWidgetItem) -> None:
+        if not self._allow_review_departure():
+            self._refresh_photo_list()
+            return
         cluster_index = item.data(LIST_CLUSTER_ROLE)
         round_index = item.data(LIST_SECTION_ROLE)
         if isinstance(cluster_index, int):
@@ -786,6 +848,8 @@ class PickBestStepWidget(QWidget):
     def _load_cluster(self, index: int) -> None:
         if not self._tournaments:
             return
+        if index != self._cluster_index and not self._allow_review_departure():
+            return
         self._cluster_index = max(0, min(index, len(self._tournaments) - 1))
         tournament = self._current_tournament()
         all_paths = list(tournament.payload.get("all_paths", []))
@@ -805,6 +869,16 @@ class PickBestStepWidget(QWidget):
 
     def focus_image(self, path: str) -> bool:
         """Open and focus the comparison containing path without changing decisions."""
+
+        if self.has_unconfirmed_changes():
+            if path not in self._subset_paths:
+                self.show_confirm_or_reset_required()
+                return False
+            self._focused_slot_index = self._subset_paths.index(path)
+            self._update_focus_state()
+            if self._focus_mode:
+                self._sync_viewer.set_focused_viewer(self._focused_slot_index)
+            return True
 
         cluster_index = next(
             (
@@ -941,6 +1015,7 @@ class PickBestStepWidget(QWidget):
         )
         self._confirm_btn.setEnabled(not group.confirmed)
         self._confirm_btn.setText("Confirmed" if group.confirmed else "Confirm  →")
+        self._reset_btn.setEnabled(self.has_unconfirmed_changes() or group.confirmed)
         self._keep_all_btn.setEnabled(not (group.confirmed and group.keep_all))
         self._keep_all_btn.setText(
             "All kept"
@@ -952,7 +1027,13 @@ class PickBestStepWidget(QWidget):
         )
         self._done_btn.setEnabled(has_completed_cluster)
         kept_count = sum(group.keep_by_path.get(path, False) for path in group.paths)
-        if group.confirmed:
+        if self.has_unconfirmed_changes():
+            self._state_banner.set_state(
+                "Set each photo, then confirm",
+                "Your Keep/Trash changes are local until you press Confirm.",
+                tone="warning",
+            )
+        elif group.confirmed:
             advancing_name = os.path.basename(group.advancing_path)
             self._state_banner.set_state(
                 "Decisions confirmed",
@@ -1061,6 +1142,13 @@ class PickBestStepWidget(QWidget):
                 card.set_focused(index == self._focused_slot_index)
 
     def _publish_confirmed_state(self, mark_state: dict[str, bool]) -> None:
+        if self.receivers(self.deletion_state_requested):
+            self._publishing_confirmation = True
+            try:
+                self.deletion_state_requested.emit(mark_state)
+            finally:
+                self._publishing_confirmation = False
+            return
         to_mark = [path for path, marked in mark_state.items() if marked]
         to_unmark = [path for path, marked in mark_state.items() if not marked]
         self._publishing_confirmation = True
@@ -1230,12 +1318,16 @@ class PickBestStepWidget(QWidget):
         self._advance_after_confirmation()
 
     def _next_cluster(self) -> None:
+        if not self._allow_review_departure():
+            return
         if self._cluster_index < len(self._tournaments) - 1:
             self._exit_focus_mode()
             self._load_cluster(self._cluster_index + 1)
             self._publish_focused_path()
 
     def _prev_cluster(self) -> None:
+        if not self._allow_review_departure():
+            return
         if self._cluster_index > 0:
             self._exit_focus_mode()
             self._load_cluster(self._cluster_index - 1)
@@ -1244,6 +1336,8 @@ class PickBestStepWidget(QWidget):
     def _next_group(self) -> None:
         """Move down within comparison history, then into the next cluster."""
 
+        if not self._allow_review_departure():
+            return
         if not self._tournaments:
             return
         tournament = self._current_tournament()
@@ -1255,6 +1349,8 @@ class PickBestStepWidget(QWidget):
     def _prev_group(self) -> None:
         """Move up within comparison history, then into the previous cluster."""
 
+        if not self._allow_review_departure():
+            return
         if not self._tournaments:
             return
         if self._current_tournament().current_round > 0:
@@ -1263,6 +1359,8 @@ class PickBestStepWidget(QWidget):
             self._prev_cluster()
 
     def _next_round(self) -> None:
+        if not self._allow_review_departure():
+            return
         tournament = self._current_tournament()
         if tournament.current_round + 1 < len(tournament.rounds):
             tournament.current_round += 1
@@ -1272,6 +1370,8 @@ class PickBestStepWidget(QWidget):
             self._show_current_group()
 
     def _prev_round(self) -> None:
+        if not self._allow_review_departure():
+            return
         tournament = self._current_tournament()
         if tournament.current_round > 0:
             tournament.current_round -= 1
@@ -1287,6 +1387,8 @@ class PickBestStepWidget(QWidget):
         self._select_path(path)
 
     def _on_apply(self) -> None:
+        if not self._allow_review_departure():
+            return
         if not self._tournaments or not any(
             tournament.finalized for tournament in self._tournaments
         ):

--- a/src/ui/workflow_review_components.py
+++ b/src/ui/workflow_review_components.py
@@ -19,6 +19,7 @@ from PyQt6.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QListWidget,
+    QDialog,
     QPushButton,
     QSizePolicy,
     QVBoxLayout,
@@ -53,6 +54,10 @@ _WORKFLOW_STEP_SHORTCUT = WorkflowShortcutSpec(
 )
 _APPLY_SHORTCUT = WorkflowShortcutSpec(
     "apply", ("Shift+Return", "Shift+Enter"), "Shift+Enter", "Apply"
+)
+_RESET_DEFAULT_SHORTCUT = WorkflowShortcutSpec("reset", ("R",), "R", "Reset default")
+_RESET_ALL_DEFAULTS_SHORTCUT = WorkflowShortcutSpec(
+    "reset_all", ("Shift+R",), "Shift+R", "Reset all"
 )
 
 
@@ -93,6 +98,8 @@ EASY_DELETE_SHORTCUTS = (
     WorkflowShortcutSpec("previous", ("Up",), "↑", "Previous"),
     WorkflowShortcutSpec("next", ("Down",), "↓", "Next"),
     WorkflowShortcutSpec("confirm", ("Return", "Enter"), "Enter", "Confirm / cancel"),
+    _RESET_DEFAULT_SHORTCUT,
+    _RESET_ALL_DEFAULTS_SHORTCUT,
     _APPLY_SHORTCUT,
     WorkflowShortcutSpec("apply_all", ("A",), "A", "All"),
     WorkflowShortcutSpec("info", ("I",), "I", "Details"),
@@ -101,11 +108,13 @@ EASY_DELETE_SHORTCUTS = (
 )
 
 FIX_ROTATION_SHORTCUTS = (
-    WorkflowShortcutSpec("rotate_counterclockwise", ("R",), "R", "−90° override"),
-    WorkflowShortcutSpec("rotate_clockwise", ("Shift+R",), "Shift+R", "+90° override"),
+    WorkflowShortcutSpec("rotate_counterclockwise", ("Q",), "Q", "−90° override"),
+    WorkflowShortcutSpec("rotate_clockwise", ("E",), "E", "+90° override"),
     WorkflowShortcutSpec("previous", ("Left", "Up"), "←  ↑", "Previous"),
     WorkflowShortcutSpec("next", ("Right", "Down"), "→  ↓", "Next"),
     WorkflowShortcutSpec("primary", ("Return", "Enter"), "Enter", "Confirm"),
+    _RESET_DEFAULT_SHORTCUT,
+    _RESET_ALL_DEFAULTS_SHORTCUT,
     _APPLY_SHORTCUT,
     _TOGGLE_LEFT_PANEL_SHORTCUT,
     _WORKFLOW_STEP_SHORTCUT,
@@ -119,6 +128,8 @@ PICK_BEST_SHORTCUTS = (
     WorkflowShortcutSpec("info", ("I",), "I", "Details"),
     WorkflowShortcutSpec("keep_all", ("K",), "K", "Keep all"),
     WorkflowShortcutSpec("confirm", ("Return", "Enter"), "Enter", "Confirm"),
+    _RESET_DEFAULT_SHORTCUT,
+    _RESET_ALL_DEFAULTS_SHORTCUT,
     _APPLY_SHORTCUT,
     _TOGGLE_LEFT_PANEL_SHORTCUT,
     _WORKFLOW_STEP_SHORTCUT,
@@ -147,6 +158,142 @@ WORKFLOW_SHORTCUTS = {
     "pick_best": PICK_BEST_SHORTCUTS,
     "cull": CULL_SHORTCUTS,
 }
+
+
+class ConfirmOrResetDialog(QDialog):
+    """Focused workflow dialog with direct actions instead of a generic warning."""
+
+    def __init__(
+        self,
+        parent: QWidget,
+        *,
+        confirm: Callable[[], None],
+        reset: Callable[[], None],
+        reset_all: Callable[[], None],
+    ) -> None:
+        super().__init__(parent)
+        self._confirm = confirm
+        self._reset = reset
+        self._reset_all = reset_all
+        self.setObjectName("confirmOrResetDialog")
+        self.setWindowTitle("Finish this photo first")
+        self.setWindowModality(Qt.WindowModality.ApplicationModal)
+        self.setMinimumWidth(520)
+        self.setMaximumWidth(620)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(28, 26, 28, 24)
+        layout.setSpacing(14)
+
+        eyebrow = QLabel("UNCONFIRMED CHANGE")
+        eyebrow.setObjectName("confirmOrResetEyebrow")
+        layout.addWidget(eyebrow)
+
+        self.title_label = QLabel("Finish this photo first")
+        self.title_label.setObjectName("confirmOrResetTitle")
+        layout.addWidget(self.title_label)
+
+        self.message_label = QLabel(
+            "You changed this review, so PhotoSort kept you on the current photo."
+        )
+        self.message_label.setObjectName("confirmOrResetMessage")
+        self.message_label.setWordWrap(True)
+        layout.addWidget(self.message_label)
+
+        explanation = QFrame()
+        explanation.setObjectName("confirmOrResetExplanation")
+        explanation_layout = QVBoxLayout(explanation)
+        explanation_layout.setContentsMargins(16, 14, 16, 14)
+        explanation_layout.setSpacing(8)
+
+        self.confirm_explanation_label = QLabel(
+            "<b>Confirm decision · Enter</b> records this review choice. "
+            "It does not apply changes to your files."
+        )
+        self.confirm_explanation_label.setObjectName("confirmOrResetOption")
+        self.confirm_explanation_label.setWordWrap(True)
+        explanation_layout.addWidget(self.confirm_explanation_label)
+
+        self.reset_explanation_label = QLabel(
+            "<b>Reset · R</b> unconfirms this review and restores PhotoSort's "
+            "suggestion. <b>Reset all · Shift+R</b> restores every review."
+        )
+        self.reset_explanation_label.setObjectName("confirmOrResetOption")
+        self.reset_explanation_label.setWordWrap(True)
+        explanation_layout.addWidget(self.reset_explanation_label)
+        layout.addWidget(explanation)
+
+        self.hint_label = QLabel("Use Apply later when you are ready to change files.")
+        self.hint_label.setObjectName("confirmOrResetHint")
+        self.hint_label.setWordWrap(True)
+        layout.addWidget(self.hint_label)
+
+        buttons = QHBoxLayout()
+        buttons.setSpacing(10)
+        buttons.addStretch(1)
+
+        self.reset_button = QPushButton("Reset to suggestion  (R)")
+        self.reset_button.setObjectName("confirmOrResetResetButton")
+        self.reset_button.setToolTip("Discard this edit and restore the suggestion (R)")
+        self.reset_button.clicked.connect(self._reset_and_close)
+        buttons.addWidget(self.reset_button)
+
+        self.confirm_button = QPushButton("Confirm decision  (Enter)")
+        self.confirm_button.setObjectName("confirmOrResetConfirmButton")
+        self.confirm_button.setToolTip("Save this review decision (Enter)")
+        self.confirm_button.setDefault(True)
+        self.confirm_button.clicked.connect(self._confirm_and_close)
+        buttons.addWidget(self.confirm_button)
+        layout.addLayout(buttons)
+
+    def _confirm_and_close(self) -> None:
+        self.accept()
+        self._confirm()
+
+    def _reset_and_close(self) -> None:
+        self.accept()
+        self._reset()
+
+    def _reset_all_and_close(self) -> None:
+        self.accept()
+        self._reset_all()
+
+    def keyPressEvent(self, event) -> None:
+        if event.key() == Qt.Key.Key_R:
+            if event.modifiers() & Qt.KeyboardModifier.ShiftModifier:
+                self._reset_all_and_close()
+            else:
+                self._reset_and_close()
+            return
+        super().keyPressEvent(event)
+
+
+def show_confirm_or_reset_notice(
+    owner: QWidget,
+    *,
+    confirm: Callable[[], None],
+    reset: Callable[[], None],
+    reset_all: Callable[[], None],
+) -> None:
+    """Explain why navigation was blocked and offer the two valid actions."""
+
+    existing = getattr(owner, "_confirm_or_reset_dialog", None)
+    if existing is not None and existing.isVisible():
+        existing.raise_()
+        existing.activateWindow()
+        return
+
+    dialog = ConfirmOrResetDialog(
+        owner.window(),
+        confirm=confirm,
+        reset=reset,
+        reset_all=reset_all,
+    )
+    owner._confirm_or_reset_dialog = dialog
+    dialog.finished.connect(
+        lambda _result: setattr(owner, "_confirm_or_reset_dialog", None)
+    )
+    dialog.open()
 
 
 def _refresh_style(widget: QWidget) -> None:

--- a/src/workers/thumbnail_preload_worker.py
+++ b/src/workers/thumbnail_preload_worker.py
@@ -228,7 +228,10 @@ class ThumbnailPreloadWorker(QObject):
                         )
                         paused_emitted = False
 
-                    if available and not background_paused:
+                    foreground_inflight = any(
+                        was_foreground for _path, was_foreground in futures.values()
+                    )
+                    if available and not background_paused and not foreground_inflight:
                         for path in self._take_background(available):
                             future = executor.submit(
                                 self._ensure,

--- a/tests/test_active_image_controller.py
+++ b/tests/test_active_image_controller.py
@@ -70,3 +70,22 @@ def test_active_path_can_be_cleared_and_updated_centrally():
     adapter.focus_image.assert_called_once_with("/photos/new.jpg")
     assert controller.clear_if_active("/photos/new.jpg")
     assert context.app_state.focused_image_path is None
+
+
+def test_external_publish_cannot_replace_active_path_during_dirty_review():
+    context = _Context()
+    context.app_state.workflow_step = "easy_delete"
+    context.app_state.focused_image_path = "/photos/current.jpg"
+    dirty_review = SimpleNamespace(
+        has_unconfirmed_changes=lambda: True,
+        show_confirm_or_reset_required=Mock(),
+        focus_image=Mock(return_value=True),
+    )
+    context.adapters = {"easy_delete": dirty_review}
+    controller = ActiveImageController(context)
+
+    assert not controller.publish("/photos/other.jpg", source="cull")
+
+    assert context.app_state.focused_image_path == "/photos/current.jpg"
+    dirty_review.show_confirm_or_reset_required.assert_called_once_with()
+    dirty_review.focus_image.assert_not_called()

--- a/tests/test_advanced_image_viewer.py
+++ b/tests/test_advanced_image_viewer.py
@@ -67,6 +67,26 @@ def test_preview_upgrade_does_not_rebuild_view_mode():
     viewer.deleteLater()
 
 
+def test_one_physical_image_click_emits_one_synchronized_click():
+    viewer = SynchronizedImageViewer()
+    viewer.resize(600, 400)
+    viewer.show()
+    viewer.set_image_data(_make_image("single-click.jpg", size=200))
+    QTest.qWait(40)
+    clicks = QSignalSpy(viewer.imageClicked)
+    viewport = viewer.image_viewers[0].image_view.viewport()
+
+    QTest.mousePress(viewport, Qt.MouseButton.LeftButton)
+    assert len(clicks) == 0
+
+    QTest.mouseRelease(viewport, Qt.MouseButton.LeftButton)
+    _app.processEvents()
+
+    assert len(clicks) == 1
+    assert clicks[0] == [0, "single-click.jpg"]
+    viewer.deleteLater()
+
+
 def test_preview_upgrade_can_preserve_normalized_crop():
     viewer = SynchronizedImageViewer()
     viewer.resize(700, 500)

--- a/tests/test_app_state_media_index.py
+++ b/tests/test_app_state_media_index.py
@@ -35,6 +35,23 @@ def test_scan_batches_maintain_media_summary_and_path_index():
     assert state.get_file_data_by_path("a.jpg")["is_blurred"] is True
 
 
+def test_bulk_deletion_marks_update_atomically():
+    state = _state()
+    state.marked_for_deletion = {"keep-marked.jpg", "remove-mark.jpg"}
+
+    changed = state.set_deletion_marks(
+        {
+            "keep-marked.jpg": True,
+            "remove-mark.jpg": False,
+            "new-mark.jpg": True,
+            "stay-clear.jpg": False,
+        }
+    )
+
+    assert changed == 2
+    assert state.marked_for_deletion == {"keep-marked.jpg", "new-mark.jpg"}
+
+
 def test_assignment_removal_and_rename_keep_index_consistent():
     state = _state()
     state.image_files_data = [

--- a/tests/test_keyboard_layout_asset.py
+++ b/tests/test_keyboard_layout_asset.py
@@ -51,14 +51,18 @@ def test_keyboard_layout_documents_current_workflow_shortcuts():
     assert "Skip" not in fix_rotation
     assert "Skip" not in pick_best
     assert "Shift+Enter Apply" in easy_delete
+    assert "R · Reset current · Shift+R · Reset all" in easy_delete
     assert "1 · Toggle left image Keep / Trash" in easy_delete
     assert "2 · Toggle right image Keep / Trash" in easy_delete
     assert "Confirm visible suggestions" in easy_delete
     assert "Trash left image" not in easy_delete
     assert "Trash right image" not in easy_delete
-    assert "1 · R −90° · Shift+R +90° override" in fix_rotation
+    assert "Q · −90° override" in fix_rotation
+    assert "E · +90° override" in fix_rotation
+    assert "R · Reset current · Shift+R · Reset all" in fix_rotation
     assert "Previous comparison / cluster" in pick_best
     assert "1 · Toggle image 1 Keep / Trash" in pick_best
     assert "2 · Toggle image 2 Keep / Trash" in pick_best
+    assert "R · Reset current · Shift+R · Reset all" in pick_best
     for section in (organize, easy_delete, fix_rotation, pick_best, cull):
         assert "Shift+Enter · Apply" in section

--- a/tests/test_thumbnail_preload_worker.py
+++ b/tests/test_thumbnail_preload_worker.py
@@ -61,6 +61,8 @@ class TestThumbnailPreloadWorker:
         pipeline = Mock()
         initial_batch_started = threading.Event()
         release_background = threading.Event()
+        jump_started = threading.Event()
+        release_jump = threading.Event()
         state_lock = threading.Lock()
         calls = []
         initial_background_count = 0
@@ -80,6 +82,9 @@ class TestThumbnailPreloadWorker:
                         initial_batch_started.set()
             if path.startswith("background-") and path != "background-5":
                 release_background.wait(timeout=2)
+            elif path == "jump-target":
+                jump_started.set()
+                release_jump.wait(timeout=2)
             return True
 
         pipeline.ensure_thumbnail_cached.side_effect = ensure
@@ -101,6 +106,12 @@ class TestThumbnailPreloadWorker:
 
         worker.prioritize(["jump-target"])
         release_background.set()
+        assert jump_started.wait(timeout=2)
+
+        with state_lock:
+            assert ("background-5", True) not in calls
+
+        release_jump.set()
         thread.join(timeout=2)
 
         assert not thread.is_alive()

--- a/tests/test_workflow_review_ui.py
+++ b/tests/test_workflow_review_ui.py
@@ -13,6 +13,7 @@ from PyQt6.QtWidgets import (
     QApplication,
     QFrame,
     QLabel,
+    QMainWindow,
     QPushButton,
     QStyleOptionViewItem,
     QVBoxLayout,
@@ -32,6 +33,7 @@ from ui.workflow_review_components import (
     ORGANIZE_SHORTCUTS,
     PICK_BEST_SHORTCUTS,
     WORKFLOW_SHORTCUTS,
+    ConfirmOrResetDialog,
     WorkflowDecisionCard,
     WorkflowShortcutStrip,
 )
@@ -81,8 +83,7 @@ def test_easy_delete_requires_confirmation_before_staging_trash(monkeypatch):
     assert "exact_duplicate" not in widget._category_checkboxes
     assert widget._items_list.item(1).text() == "delete.jpg  ↔  keep.jpg"
     assert not (widget._items_list.item(0).flags() & Qt.ItemFlag.ItemIsSelectable)
-    assert "SELECTED FOR TRASH" in widget._pair_left_hdr.text()
-    assert "not confirmed" in widget._pair_left_hdr.text()
+    assert widget._pair_left_hdr.text() == "TRASH"
     assert (
         widget._pair_left_card._name_label.text()
         == "delete.jpg · Suggested for trash · lower sharpness (10.0 vs 25.0)"
@@ -131,8 +132,8 @@ def test_easy_delete_requires_confirmation_before_staging_trash(monkeypatch):
     _app.processEvents()
 
     assert not marks
-    assert "SELECTED FOR TRASH" in widget._pair_left_hdr.text()
-    assert "SELECTED FOR TRASH" in widget._pair_right_hdr.text()
+    assert widget._pair_left_hdr.text() == "TRASH"
+    assert widget._pair_right_hdr.text() == "TRASH"
 
     widget._on_confirm()
     _app.processEvents()
@@ -144,8 +145,8 @@ def test_easy_delete_requires_confirmation_before_staging_trash(monkeypatch):
     )
     assert widget._items_list.item(1).text().startswith("✓")
     assert widget._items_list.item(1).text().endswith("Complete · 0 kept")
-    assert "MARKED FOR TRASH" in widget._pair_left_hdr.text()
-    assert "MARKED FOR TRASH" in widget._pair_right_hdr.text()
+    assert widget._pair_left_hdr.text() == "TRASH"
+    assert widget._pair_right_hdr.text() == "TRASH"
 
 
 def test_easy_delete_revision_restores_prior_marks_until_reconfirmed():
@@ -185,14 +186,115 @@ def test_easy_delete_revision_restores_prior_marks_until_reconfirmed():
     assert not widget._confirmed_reviews
     assert widget._state_banner.title_label.text() == "Set each photo, then confirm"
     assert widget._confirm_btn.text() == "Confirm  →"
-    assert "SELECTED TO KEEP" in widget._pair_left_hdr.text()
-    assert "SELECTED FOR TRASH" in widget._pair_right_hdr.text()
+    assert widget._pair_left_hdr.text() == "KEEP"
+    assert widget._pair_right_hdr.text() == "TRASH"
 
     shortcuts["Return"].activated.emit()
     _app.processEvents()
 
     assert marks == {pair_path}
     assert widget._confirmed_reviews == {review_path}
+
+
+def test_easy_delete_r_unconfirms_and_restores_default_and_prior_marks():
+    review_path = "/tmp/reset-confirmed-review.jpg"
+    pair_path = "/tmp/reset-confirmed-pair.jpg"
+    marks = {pair_path}
+    widget = EasyDeleteStepWidget()
+    widget.set_is_marked_func(marks.__contains__)
+    widget.mark_for_deletion_requested.connect(lambda paths: marks.update(paths))
+    widget.unmark_for_deletion_requested.connect(
+        lambda paths: marks.difference_update(paths)
+    )
+    widget.show_results(
+        {
+            review_path: {
+                "type": "duplicate",
+                "pair_path": pair_path,
+                "suggest_delete": True,
+            }
+        }
+    )
+    shortcuts = {shortcut.key().toString(): shortcut for shortcut in widget._shortcuts}
+
+    shortcuts["Return"].activated.emit()
+    assert marks == {review_path}
+    assert widget._confirmed_reviews == {review_path}
+
+    shortcuts["R"].activated.emit()
+
+    assert marks == {pair_path}
+    assert not widget._confirmed_reviews
+    assert widget._pair_left_hdr.text() == "TRASH"
+    assert widget._pair_right_hdr.text() == "KEEP"
+
+
+def test_easy_delete_shift_r_resets_all_confirmed_reviews():
+    first = "/tmp/reset-all-first.jpg"
+    second = "/tmp/reset-all-second.jpg"
+    marks: set[str] = set()
+    widget = EasyDeleteStepWidget()
+    widget.set_is_marked_func(marks.__contains__)
+    widget.mark_for_deletion_requested.connect(lambda paths: marks.update(paths))
+    widget.unmark_for_deletion_requested.connect(
+        lambda paths: marks.difference_update(paths)
+    )
+    widget.show_results(
+        {
+            first: {"type": "blur", "pair_path": None, "suggest_delete": True},
+            second: {"type": "dark", "pair_path": None, "suggest_delete": True},
+        }
+    )
+    shortcuts = {shortcut.key().toString(): shortcut for shortcut in widget._shortcuts}
+
+    shortcuts["Return"].activated.emit()
+    shortcuts["Return"].activated.emit()
+    assert marks == {first, second}
+    assert widget._confirmed_reviews == {first, second}
+
+    shortcuts["Shift+R"].activated.emit()
+
+    assert not marks
+    assert not widget._confirmed_reviews
+    assert all(
+        state == widget._default_keep_state(path, widget._results[path])
+        for path, state in widget._pending_keep_by_review.items()
+    )
+
+
+def test_easy_delete_bulk_actions_publish_one_atomic_mark_update():
+    results = {
+        f"/tmp/bulk-{index}.jpg": {
+            "type": "blur",
+            "pair_path": None,
+            "suggest_delete": True,
+        }
+        for index in range(40)
+    }
+    batch_updates: list[dict[str, bool]] = []
+    legacy_mark_updates: list[list[str]] = []
+    legacy_unmark_updates: list[list[str]] = []
+    widget = EasyDeleteStepWidget()
+    widget.set_is_marked_func(lambda _path: False)
+    widget.deletion_state_requested.connect(batch_updates.append)
+    widget.mark_for_deletion_requested.connect(legacy_mark_updates.append)
+    widget.unmark_for_deletion_requested.connect(legacy_unmark_updates.append)
+    widget.show_results(results)
+    shortcuts = {shortcut.key().toString(): shortcut for shortcut in widget._shortcuts}
+
+    shortcuts["A"].activated.emit()
+
+    assert len(batch_updates) == 1
+    assert batch_updates[0] == dict.fromkeys(results, True)
+    assert not legacy_mark_updates
+    assert not legacy_unmark_updates
+
+    batch_updates.clear()
+    shortcuts["Shift+R"].activated.emit()
+
+    assert len(batch_updates) == 1
+    assert batch_updates[0] == dict.fromkeys(results, False)
+    assert not widget._confirmed_reviews
 
 
 def test_easy_delete_pair_supports_all_independent_keep_trash_outcomes():
@@ -227,15 +329,15 @@ def test_easy_delete_pair_supports_all_independent_keep_trash_outcomes():
             shortcut.key().toString(): shortcut for shortcut in widget._shortcuts
         }
 
-        assert "SELECTED FOR TRASH" in widget._pair_left_hdr.text()
-        assert "SELECTED TO KEEP" in widget._pair_right_hdr.text()
+        assert widget._pair_left_hdr.text() == "TRASH"
+        assert widget._pair_right_hdr.text() == "KEEP"
         for key in toggles:
             shortcuts[key].activated.emit()
         _app.processEvents()
 
         assert not marks
-        assert ("SELECTED TO KEEP" in widget._pair_left_hdr.text()) is keep_left
-        assert ("SELECTED TO KEEP" in widget._pair_right_hdr.text()) is keep_right
+        assert (widget._pair_left_hdr.text() == "KEEP") is keep_left
+        assert (widget._pair_right_hdr.text() == "KEEP") is keep_right
 
         shortcuts["Return"].activated.emit()
         _app.processEvents()
@@ -271,16 +373,44 @@ def test_easy_delete_card_click_toggles_only_the_target_photo():
     widget._pair_left_card.activated.emit()
     _app.processEvents()
 
-    assert "SELECTED TO KEEP" in widget._pair_left_hdr.text()
-    assert "SELECTED TO KEEP" in widget._pair_right_hdr.text()
+    assert widget._pair_left_hdr.text() == "KEEP"
+    assert widget._pair_right_hdr.text() == "KEEP"
     assert not marks
 
     widget._pair_right_card.activated.emit()
     _app.processEvents()
 
-    assert "SELECTED TO KEEP" in widget._pair_left_hdr.text()
-    assert "SELECTED FOR TRASH" in widget._pair_right_hdr.text()
+    assert widget._pair_left_hdr.text() == "KEEP"
+    assert widget._pair_right_hdr.text() == "TRASH"
     assert not marks
+
+
+def test_easy_delete_physical_image_click_toggles_once_and_stays_toggled():
+    left = "/tmp/physical-click-left.jpg"
+    right = "/tmp/physical-click-right.jpg"
+    widget = EasyDeleteStepWidget()
+    widget.resize(900, 650)
+    widget.set_is_marked_func(lambda _path: False)
+    widget.show_results(
+        {
+            left: {
+                "type": "duplicate",
+                "pair_path": right,
+                "suggest_delete": True,
+                "reason": "Detector default",
+            }
+        }
+    )
+    widget.show()
+    QTest.qWait(40)
+    viewport = widget._sync_viewer.image_viewers[0].image_view.viewport()
+
+    QTest.mouseClick(viewport, Qt.MouseButton.LeftButton)
+    _app.processEvents()
+
+    assert widget._pair_left_hdr.text() == "KEEP"
+    assert widget._pair_right_hdr.text() == "KEEP"
+    assert widget.has_unconfirmed_changes()
 
 
 def test_easy_delete_shift_enter_requests_apply():
@@ -359,7 +489,7 @@ def test_easy_delete_confirm_advances_and_confirm_all_uses_suggestions():
 
     assert first in marks
     assert widget._current_index == 1
-    assert "SELECTED FOR TRASH" in widget._single_hdr.text()
+    assert widget._single_hdr.text() == "TRASH"
     assert len(widget._sync_viewer.image_viewers) == 1
 
     widget._on_apply_all()
@@ -564,10 +694,74 @@ def test_easy_delete_arrow_shortcuts_separate_choice_from_navigation():
     shortcuts["Right"].activated.emit()
 
     assert widget._current_index == 0
-    assert "SELECTED FOR TRASH" in widget._pair_right_hdr.text()
+    assert widget._pair_right_hdr.text() == "TRASH"
 
     shortcuts["Down"].activated.emit()
 
+    assert widget._current_index == 0
+    assert widget._confirm_or_reset_dialog.isVisible()
+
+    shortcuts["R"].activated.emit()
+    shortcuts["Down"].activated.emit()
+
+    assert widget._current_index == 1
+
+
+def test_easy_delete_dirty_review_blocks_departure_until_r_resets_default():
+    first = "/tmp/dirty-first.jpg"
+    partner = "/tmp/dirty-partner.jpg"
+    second = "/tmp/dirty-second.jpg"
+    marks: set[str] = set()
+    apply_requests: list[bool] = []
+    widget = EasyDeleteStepWidget()
+    widget.set_is_marked_func(marks.__contains__)
+    widget.apply_requested.connect(lambda: apply_requests.append(True))
+    widget.show_results(
+        {
+            first: {
+                "type": "duplicate",
+                "pair_path": partner,
+                "suggest_delete": True,
+                "duplicate_kind": "exact",
+            },
+            second: {
+                "type": "blur",
+                "pair_path": None,
+                "suggest_delete": True,
+            },
+        }
+    )
+    shortcuts = {shortcut.key().toString(): shortcut for shortcut in widget._shortcuts}
+
+    assert not widget.has_unconfirmed_changes()
+    shortcuts["1"].activated.emit()
+    assert widget.has_unconfirmed_changes()
+    assert widget._reset_btn.isEnabled()
+
+    widget._on_next()
+    blocked_item = widget._items_list.item(3)
+    widget._items_list.setCurrentItem(blocked_item)
+    widget._items_list.itemClicked.emit(blocked_item)
+    assert not widget.focus_image(second)
+    widget._category_checkboxes["exact_duplicate"].setChecked(False)
+    shortcuts["Shift+Return"].activated.emit()
+
+    assert widget._current_index == 0
+    assert widget._items_list.currentItem().data(Qt.ItemDataRole.UserRole) == first
+    assert widget._category_checkboxes["exact_duplicate"].isChecked()
+    assert widget._visible_image_paths == (first, partner)
+    assert widget._confirm_or_reset_dialog.isVisible()
+    assert not marks
+    assert not apply_requests
+
+    shortcuts["R"].activated.emit()
+
+    assert not widget.has_unconfirmed_changes()
+    assert widget._pair_left_hdr.text() == "TRASH"
+    assert widget._pair_right_hdr.text() == "KEEP"
+    assert not widget._reset_btn.isEnabled()
+
+    widget._on_next()
     assert widget._current_index == 1
 
 
@@ -790,7 +984,7 @@ def test_fix_rotation_distinguishes_preview_queue_and_applied_state():
     assert not widget._ordered_paths
 
 
-def test_fix_rotation_manual_shortcut_cycles_clockwise_and_queues_override():
+def test_fix_rotation_e_shortcut_cycles_clockwise_and_queues_override():
     path = "/tmp/sideways.jpg"
     widget = FixRotationStepWidget()
     widget.show_results({path: 90})
@@ -798,7 +992,7 @@ def test_fix_rotation_manual_shortcut_cycles_clockwise_and_queues_override():
     assert "A" not in shortcuts
     assert "Space" not in shortcuts
 
-    shortcuts["Shift+R"].activated.emit()
+    shortcuts["E"].activated.emit()
     _app.processEvents()
 
     assert widget._selected_angle(path) == 180
@@ -810,8 +1004,8 @@ def test_fix_rotation_manual_shortcut_cycles_clockwise_and_queues_override():
     widget._on_confirm()
     assert widget.pending_rotations() == {path: 180}
 
-    shortcuts["Shift+R"].activated.emit()
-    shortcuts["Shift+R"].activated.emit()
+    shortcuts["E"].activated.emit()
+    shortcuts["E"].activated.emit()
     _app.processEvents()
 
     assert widget._selected_angle(path) == 0
@@ -819,7 +1013,7 @@ def test_fix_rotation_manual_shortcut_cycles_clockwise_and_queues_override():
     assert path not in widget._confirmed
     assert widget.pending_rotations() == {}
 
-    shortcuts["Shift+R"].activated.emit()
+    shortcuts["E"].activated.emit()
     _app.processEvents()
 
     assert widget._selected_angle(path) == 90
@@ -827,13 +1021,13 @@ def test_fix_rotation_manual_shortcut_cycles_clockwise_and_queues_override():
     assert widget._marked[path]
 
 
-def test_fix_rotation_r_rotates_counterclockwise_instead_of_toggling_selection():
+def test_fix_rotation_q_rotates_counterclockwise_instead_of_toggling_selection():
     path = "/tmp/upside-down.jpg"
     widget = FixRotationStepWidget()
     widget.show_results({path: 180})
     shortcuts = {shortcut.key().toString(): shortcut for shortcut in widget._shortcuts}
 
-    shortcuts["R"].activated.emit()
+    shortcuts["Q"].activated.emit()
     _app.processEvents()
 
     assert widget._selected_angle(path) == 90
@@ -844,12 +1038,36 @@ def test_fix_rotation_r_rotates_counterclockwise_instead_of_toggling_selection()
     widget._on_confirm()
     assert widget.pending_rotations() == {path: 90}
 
-    shortcuts["R"].activated.emit()
+    shortcuts["Q"].activated.emit()
     _app.processEvents()
 
     assert widget._selected_angle(path) == 0
     assert not widget._marked[path]
     assert path not in widget._confirmed
+
+
+def test_fix_rotation_r_unconfirms_and_shift_r_resets_all():
+    first = "/tmp/reset-rotation-first.jpg"
+    second = "/tmp/reset-rotation-second.jpg"
+    widget = FixRotationStepWidget()
+    widget.show_results({first: 90, second: -90})
+    shortcuts = {shortcut.key().toString(): shortcut for shortcut in widget._shortcuts}
+
+    widget._on_confirm_all()
+    assert widget._confirmed == {first, second}
+    assert widget.pending_rotations() == {first: 90, second: -90}
+
+    shortcuts["R"].activated.emit()
+    assert first not in widget._confirmed
+    assert widget._selected_angle(first) == 90
+    assert widget.pending_rotations() == {second: -90}
+
+    shortcuts["Shift+R"].activated.emit()
+
+    assert not widget._confirmed
+    assert widget.pending_rotations() == {}
+    assert widget._selected_angle(first) == 90
+    assert widget._selected_angle(second) == -90
 
 
 def test_fix_rotation_shift_enter_applies_confirmed_rotations():
@@ -877,6 +1095,57 @@ def test_fix_rotation_clockwise_override_starts_from_original_when_unselected():
     widget._on_confirm()
 
     assert widget.pending_rotations() == {path: 90}
+
+
+def test_fix_rotation_dirty_review_blocks_departure_and_reset_restores_suggestion():
+    first = "/tmp/rotation-dirty-first.jpg"
+    second = "/tmp/rotation-dirty-second.jpg"
+    apply_requests: list[dict] = []
+    widget = FixRotationStepWidget()
+    widget.apply_rotations_requested.connect(apply_requests.append)
+    widget.show_results({first: 90, second: -90})
+    shortcuts = {shortcut.key().toString(): shortcut for shortcut in widget._shortcuts}
+
+    shortcuts["Q"].activated.emit()
+    assert widget.has_unconfirmed_changes()
+    assert widget._selected_angle(first) == 0
+
+    widget._on_next()
+    blocked_item = widget._items_list.item(1)
+    widget._items_list.setCurrentItem(blocked_item)
+    widget._items_list.itemClicked.emit(blocked_item)
+    assert not widget.focus_image(second)
+    shortcuts["Shift+Return"].activated.emit()
+
+    assert widget._current_index == 0
+    assert widget._items_list.currentItem().data(Qt.ItemDataRole.UserRole) == first
+    assert widget._confirm_or_reset_dialog.isVisible()
+    assert not widget.pending_rotations()
+    assert not apply_requests
+
+    shortcuts["R"].activated.emit()
+
+    assert not widget.has_unconfirmed_changes()
+    assert widget._selected_angle(first) == 90
+    assert widget._marked[first]
+    assert first not in widget._angle_overrides
+
+    widget._on_next()
+    assert widget._current_index == 1
+
+
+def test_fix_rotation_returning_to_suggestion_clears_dirty_state():
+    path = "/tmp/rotation-back-to-default.jpg"
+    widget = FixRotationStepWidget()
+    widget.show_results({path: 90})
+
+    widget._on_rotate_counterclockwise()
+    assert widget.has_unconfirmed_changes()
+
+    widget._on_rotate_clockwise()
+    assert not widget.has_unconfirmed_changes()
+    assert widget._selected_angle(path) == 90
+    assert path not in widget._angle_overrides
 
 
 def _pick_best_payload(paths: list[str], scores: dict[str, float] | None = None):
@@ -1124,6 +1393,207 @@ def test_pick_best_number_shortcuts_toggle_only_the_target_photo_before_confirm(
     widget._on_confirm()
     assert marks == set(paths)
     assert widget._current_tournament().final_winner == paths[1]
+
+
+def test_pick_best_dirty_review_blocks_departure_until_escape_restores_baseline():
+    first_paths = ["/tmp/pick-dirty-a.jpg", "/tmp/pick-dirty-b.jpg"]
+    second_paths = ["/tmp/pick-other-a.jpg", "/tmp/pick-other-b.jpg"]
+    marks: set[str] = set()
+    apply_requests: list[bool] = []
+    widget = PickBestStepWidget()
+    widget.set_is_marked_func(marks.__contains__)
+    widget.apply_requested.connect(lambda: apply_requests.append(True))
+    widget.show_results(
+        {
+            1: _pick_best_payload(first_paths, {first_paths[1]: 0.9}),
+            2: _pick_best_payload(second_paths, {second_paths[1]: 0.9}),
+        }
+    )
+    shortcuts = {shortcut.key().toString(): shortcut for shortcut in widget._shortcuts}
+    baseline = dict(widget._current_group().default_keep_by_path)
+
+    shortcuts["1"].activated.emit()
+    assert widget.has_unconfirmed_changes()
+    assert widget._reset_btn.isEnabled()
+
+    widget._next_cluster()
+    second_cluster_item = _pick_best_cluster_items(widget)[1]
+    widget._items_list.setCurrentItem(second_cluster_item)
+    widget._items_list.itemClicked.emit(second_cluster_item)
+    assert not widget.focus_image(second_paths[0])
+    shortcuts["Shift+Return"].activated.emit()
+
+    assert widget._cluster_index == 0
+    assert widget._items_list.currentItem() is not second_cluster_item
+    assert widget._subset_paths == first_paths
+    assert widget._confirm_or_reset_dialog.isVisible()
+    assert not marks
+    assert not apply_requests
+
+    shortcuts["R"].activated.emit()
+
+    assert not widget.has_unconfirmed_changes()
+    assert widget._current_group().keep_by_path == baseline
+    assert not widget._reset_btn.isEnabled()
+
+    widget._next_cluster()
+    assert widget._cluster_index == 1
+
+
+def test_blocked_review_navigation_shows_explanation_dialog():
+    host = QMainWindow()
+    widget = EasyDeleteStepWidget()
+    host.setCentralWidget(widget)
+    widget.set_is_marked_func(lambda _path: False)
+    widget.show_results(
+        {
+            "/tmp/notice-first.jpg": {
+                "type": "blur",
+                "pair_path": None,
+                "suggest_delete": True,
+            },
+            "/tmp/notice-second.jpg": {
+                "type": "dark",
+                "pair_path": None,
+                "suggest_delete": True,
+            },
+        }
+    )
+
+    widget._toggle_single_choice()
+    widget._on_next()
+
+    dialog = widget._confirm_or_reset_dialog
+    assert dialog.isVisible()
+    assert dialog.title_label.text() == "Finish this photo first"
+    assert dialog.message_label.text() == (
+        "You changed this review, so PhotoSort kept you on the current photo."
+    )
+    assert dialog.confirm_button.text() == "Confirm decision  (Enter)"
+    assert dialog.reset_button.text() == "Reset to suggestion  (R)"
+    assert "does not apply changes" in dialog.confirm_explanation_label.text()
+    assert "Enter" in dialog.confirm_explanation_label.text()
+    assert "R" in dialog.reset_explanation_label.text()
+    assert "Apply later" in dialog.hint_label.text()
+
+    QTest.keyClick(dialog, Qt.Key.Key_R)
+
+    assert not widget.has_unconfirmed_changes()
+    assert widget._confirm_or_reset_dialog is None
+
+
+def test_confirm_or_reset_dialog_shift_r_resets_all():
+    actions: list[str] = []
+    host = QMainWindow()
+    dialog = ConfirmOrResetDialog(
+        host,
+        confirm=lambda: actions.append("confirm"),
+        reset=lambda: actions.append("reset"),
+        reset_all=lambda: actions.append("reset_all"),
+    )
+    dialog.show()
+
+    QTest.keyClick(dialog, Qt.Key.Key_R, Qt.KeyboardModifier.ShiftModifier)
+
+    assert actions == ["reset_all"]
+    assert not dialog.isVisible()
+
+
+def test_pick_best_reset_restores_carried_comparison_default():
+    paths = [
+        "/tmp/carried-a.jpg",
+        "/tmp/carried-b.jpg",
+        "/tmp/carried-c.jpg",
+    ]
+    widget = PickBestStepWidget()
+    widget.set_is_marked_func(lambda _path: False)
+    widget.show_results({1: _pick_best_payload(paths, {paths[1]: 0.9})})
+
+    widget._select_path(paths[0])
+    widget._on_confirm()
+    group = widget._current_group()
+    baseline = dict(group.default_keep_by_path)
+
+    widget._select_path(group.paths[0])
+    assert widget.has_unconfirmed_changes()
+
+    widget.reset_current_to_default()
+
+    assert not widget.has_unconfirmed_changes()
+    assert group.keep_by_path == baseline
+
+
+def test_pick_best_r_unconfirms_and_shift_r_resets_all_clusters():
+    first_paths = ["/tmp/reset-pick-a.jpg", "/tmp/reset-pick-b.jpg"]
+    second_paths = ["/tmp/reset-pick-c.jpg", "/tmp/reset-pick-d.jpg"]
+    marks: set[str] = set()
+    widget = PickBestStepWidget()
+    widget.set_is_marked_func(marks.__contains__)
+    widget.mark_for_deletion_requested.connect(lambda paths: marks.update(paths))
+    widget.unmark_for_deletion_requested.connect(
+        lambda paths: marks.difference_update(paths)
+    )
+    widget.show_results(
+        {
+            1: _pick_best_payload(first_paths, {first_paths[1]: 0.9}),
+            2: _pick_best_payload(second_paths, {second_paths[1]: 0.9}),
+        }
+    )
+    shortcuts = {shortcut.key().toString(): shortcut for shortcut in widget._shortcuts}
+    first_default = dict(widget._current_group().default_keep_by_path)
+
+    shortcuts["Return"].activated.emit()
+    assert widget._cluster_index == 1
+    shortcuts["Return"].activated.emit()
+    assert marks == {first_paths[0], second_paths[0]}
+
+    shortcuts["R"].activated.emit()
+    assert marks == {first_paths[0]}
+    assert not widget._current_group().confirmed
+    assert (
+        widget._current_group().keep_by_path
+        == widget._current_group().default_keep_by_path
+    )
+
+    shortcuts["Shift+R"].activated.emit()
+
+    assert not marks
+    assert widget._cluster_index == 1
+    assert all(
+        not group.confirmed
+        for tournament in widget._tournaments
+        for round_ in tournament.rounds
+        for group in round_.groups
+    )
+    widget._load_cluster(0)
+    assert widget._current_group().keep_by_path == first_default
+
+
+def test_pick_best_reset_all_publishes_one_atomic_mark_update():
+    batch_updates: list[dict[str, bool]] = []
+    widget = PickBestStepWidget()
+    widget.set_is_marked_func(lambda _path: False)
+    widget.deletion_state_requested.connect(batch_updates.append)
+    clusters = {
+        index: _pick_best_payload(
+            [f"/tmp/batch-{index}-a.jpg", f"/tmp/batch-{index}-b.jpg"],
+            {f"/tmp/batch-{index}-b.jpg": 0.9},
+        )
+        for index in range(1, 6)
+    }
+    widget.show_results(clusters)
+
+    for _index in clusters:
+        widget._on_confirm()
+    batch_updates.clear()
+
+    widget.reset_all_to_default()
+
+    assert len(batch_updates) == 1
+    assert set(batch_updates[0]) == {
+        path for payload in clusters.values() for path in payload["all_paths"]
+    }
+    assert not any(batch_updates[0].values())
 
 
 def test_pick_best_click_toggles_only_the_clicked_photo():
@@ -1928,16 +2398,22 @@ def test_visible_shortcut_specs_are_the_installed_source_of_truth():
         assert len(widget._shortcuts) == expected
 
 
-def test_review_workflows_have_no_escape_skip_shortcut():
+def test_review_workflows_use_r_and_shift_r_to_reset_defaults():
     widgets_and_specs = (
         (EasyDeleteStepWidget(), EASY_DELETE_SHORTCUTS),
         (FixRotationStepWidget(), FIX_ROTATION_SHORTCUTS),
         (PickBestStepWidget(), PICK_BEST_SHORTCUTS),
     )
     for widget, specs in widgets_and_specs:
-        assert all("Escape" not in spec.sequences for spec in specs)
+        reset_spec = next(spec for spec in specs if spec.action == "reset")
+        assert reset_spec.sequences == ("R",)
+        assert reset_spec.label == "Reset default"
+        reset_all_spec = next(spec for spec in specs if spec.action == "reset_all")
+        assert reset_all_spec.sequences == ("Shift+R",)
+        assert reset_all_spec.label == "Reset all"
         installed = {shortcut.key().toString() for shortcut in widget._shortcuts}
-        assert "Esc" not in installed
+        assert "R" in installed
+        assert "Shift+R" in installed
 
 
 def test_pick_best_loading_page_has_no_skip_navigation_button():

--- a/tests/test_workflow_transition_guard.py
+++ b/tests/test_workflow_transition_guard.py
@@ -51,6 +51,35 @@ def test_clean_transition_cancels_current_analysis_and_switches_directly():
     window._show_workflow_destination.assert_called_once_with("fix_rotation")
 
 
+def test_dirty_review_blocks_workflow_switch_before_pending_resolution():
+    review = SimpleNamespace(
+        has_unconfirmed_changes=lambda: True,
+        show_confirm_or_reset_required=Mock(),
+    )
+    collect_pending = Mock()
+    show_destination = Mock()
+    window = SimpleNamespace(
+        app_state=SimpleNamespace(workflow_step="easy_delete"),
+        worker_manager=_worker_manager(),
+        app_controller=SimpleNamespace(
+            is_workflow_analysis_running=lambda _workflow: False
+        ),
+        get_active_image_adapter=lambda workflow: (
+            review if workflow == "easy_delete" else None
+        ),
+        update_workflow_navigation=Mock(),
+        _collect_workflow_pending_state=collect_pending,
+        _show_workflow_destination=show_destination,
+    )
+
+    MainWindow._request_workflow_transition(window, "fix_rotation")
+
+    review.show_confirm_or_reset_required.assert_called_once_with()
+    window.update_workflow_navigation.assert_called_once_with()
+    collect_pending.assert_not_called()
+    show_destination.assert_not_called()
+
+
 def test_stay_here_preserves_pending_work_and_running_analysis():
     controller = SimpleNamespace(
         is_workflow_analysis_running=lambda _workflow: True,


### PR DESCRIPTION
This will make it easier to understand how each step works like easy delete and when it confirms the changes

Also added reset shortcuts

- Introduced new shortcuts for resetting defaults: 'R' for current and 'Shift+R' for all.
- Implemented ConfirmOrResetDialog to handle unconfirmed changes before transitioning workflows.
- Updated existing tests to cover new functionality, ensuring proper behavior of shortcuts and dialog interactions.
- Refactored keyboard shortcuts in various components to align with new reset functionality.
- Enhanced EasyDeleteStepWidget and FixRotationStepWidget to manage dirty states and confirmations effectively.