### PR TITLE
Improve UI responsiveness and Organize navigation

### DIFF
--- a/src/core/caching/analysis_cache.py
+++ b/src/core/caching/analysis_cache.py
@@ -176,9 +176,7 @@ class AnalysisCache:
         def remap_mapping_keys(value: object) -> object:
             if not isinstance(value, dict):
                 return value
-            return {
-                path_updates.get(path, path): item for path, item in value.items()
-            }
+            return {path_updates.get(path, path): item for path, item in value.items()}
 
         for field in (
             "cluster_results",
@@ -256,8 +254,7 @@ class AnalysisCache:
                     result
                     for result in values
                     if not (
-                        isinstance(result, dict)
-                        and result.get("image_path") in removed
+                        isinstance(result, dict) and result.get("image_path") in removed
                     )
                 ]
                 if retained:
@@ -270,10 +267,7 @@ class AnalysisCache:
                         winners.pop(cluster_id, None)
         elif isinstance(winners, dict):
             for cluster_id, winner in list(winners.items()):
-                if (
-                    isinstance(winner, dict)
-                    and winner.get("image_path") in removed
-                ):
+                if isinstance(winner, dict) and winner.get("image_path") in removed:
                     winners.pop(cluster_id, None)
 
         entry["version"] = CACHE_VERSION

--- a/src/core/caching/analysis_cache.py
+++ b/src/core/caching/analysis_cache.py
@@ -73,30 +73,51 @@ class AnalysisCache:
         cluster_id: int,
         rankings: list[dict[str, object]],
     ) -> None:
+        """Persist one cluster through the batch-owned implementation."""
+
+        self.update_best_shot_results_batch(
+            folder_path,
+            {cluster_id: rankings},
+        )
+
+    def update_best_shot_results_batch(
+        self,
+        folder_path: str,
+        rankings_by_cluster: dict[int, list[dict[str, object]]],
+    ) -> None:
+        """Merge many cluster rankings with one cache read and one write."""
+
+        if not rankings_by_cluster:
+            return
         key = _normalize_folder_path(folder_path)
         entry = self.load(folder_path)
-        serialized_rankings = json.loads(json.dumps(rankings))
 
         rankings_map = entry.setdefault("best_shot_rankings", {})
         winners_map = entry.setdefault("best_shot_winners", {})
         scores_map = entry.setdefault("best_shot_scores_by_path", {})
 
-        rankings_map[str(cluster_id)] = serialized_rankings
-        winner = serialized_rankings[0] if serialized_rankings else None
-        if winner:
-            winners_map[str(cluster_id)] = winner
+        for cluster_id, rankings in rankings_by_cluster.items():
+            serialized_rankings = json.loads(json.dumps(rankings))
+            rankings_map[str(cluster_id)] = serialized_rankings
+            winner = serialized_rankings[0] if serialized_rankings else None
+            if winner:
+                winners_map[str(cluster_id)] = winner
+            else:
+                winners_map.pop(str(cluster_id), None)
 
-        for result in serialized_rankings:
-            path = result.get("image_path")
-            if path:
-                scores_map[path] = result
+            for result in serialized_rankings:
+                path = result.get("image_path")
+                if path:
+                    scores_map[path] = result
 
         entry["version"] = CACHE_VERSION
         entry["updated_at"] = time.time()
         try:
             self._cache.set(key, entry)
         except Exception:
-            logger.exception("Failed to persist best-shot results for %s", folder_path)
+            logger.exception(
+                "Failed to persist best-shot result batch for %s", folder_path
+            )
 
     def get_completed_best_shot_clusters(self, folder_path: str) -> set[int]:
         entry = self.load(folder_path)
@@ -137,6 +158,133 @@ class AnalysisCache:
             self._cache.clear()
         except Exception:
             logger.exception("Failed to clear full analysis cache")
+
+    def migrate_folder_paths(
+        self,
+        source_folder: str,
+        destination_folder: str,
+        path_updates: dict[str, str],
+    ) -> None:
+        """Move one folder's analysis state and remap every stored file path."""
+
+        if not path_updates:
+            return
+        entry = self.load(source_folder)
+        if not entry:
+            return
+
+        def remap_mapping_keys(value: object) -> object:
+            if not isinstance(value, dict):
+                return value
+            return {
+                path_updates.get(path, path): item for path, item in value.items()
+            }
+
+        for field in (
+            "cluster_results",
+            "manual_cluster_overrides",
+            "best_shot_scores_by_path",
+        ):
+            if field in entry:
+                entry[field] = remap_mapping_keys(entry[field])
+
+        for field in (
+            "best_shot_rankings",
+            "best_shot_winners",
+            "best_shot_scores_by_path",
+        ):
+            collection = entry.get(field)
+            if not isinstance(collection, dict):
+                continue
+            groups = (
+                collection.values()
+                if field == "best_shot_rankings"
+                else ([value] for value in collection.values())
+            )
+            for group in groups:
+                if not isinstance(group, list):
+                    continue
+                for result in group:
+                    if not isinstance(result, dict):
+                        continue
+                    path = result.get("image_path")
+                    if path in path_updates:
+                        result["image_path"] = path_updates[path]
+
+        entry["version"] = CACHE_VERSION
+        entry["updated_at"] = time.time()
+        source_key = _normalize_folder_path(source_folder)
+        destination_key = _normalize_folder_path(destination_folder)
+        try:
+            self._cache.set(destination_key, entry)
+            if source_key != destination_key and source_key in self._cache:
+                del self._cache[source_key]
+        except Exception:
+            logger.exception(
+                "Failed to migrate analysis cache from %s to %s",
+                source_folder,
+                destination_folder,
+            )
+
+    def remove_paths(self, folder_path: str, paths: set[str]) -> None:
+        """Remove deleted files from one analysis entry with one read/write."""
+
+        removed = {path for path in paths if path}
+        if not removed:
+            return
+        entry = self.load(folder_path)
+        if not entry:
+            return
+
+        for field in (
+            "cluster_results",
+            "manual_cluster_overrides",
+            "best_shot_scores_by_path",
+        ):
+            mapping = entry.get(field)
+            if isinstance(mapping, dict):
+                for path in removed:
+                    mapping.pop(path, None)
+
+        rankings = entry.get("best_shot_rankings")
+        winners = entry.get("best_shot_winners")
+        if isinstance(rankings, dict):
+            for cluster_id, values in list(rankings.items()):
+                if not isinstance(values, list):
+                    continue
+                retained = [
+                    result
+                    for result in values
+                    if not (
+                        isinstance(result, dict)
+                        and result.get("image_path") in removed
+                    )
+                ]
+                if retained:
+                    rankings[cluster_id] = retained
+                    if isinstance(winners, dict):
+                        winners[cluster_id] = retained[0]
+                else:
+                    rankings.pop(cluster_id, None)
+                    if isinstance(winners, dict):
+                        winners.pop(cluster_id, None)
+        elif isinstance(winners, dict):
+            for cluster_id, winner in list(winners.items()):
+                if (
+                    isinstance(winner, dict)
+                    and winner.get("image_path") in removed
+                ):
+                    winners.pop(cluster_id, None)
+
+        entry["version"] = CACHE_VERSION
+        entry["updated_at"] = time.time()
+        try:
+            self._cache.set(_normalize_folder_path(folder_path), entry)
+        except Exception:
+            logger.exception(
+                "Failed to remove deleted paths from analysis cache for %s",
+                folder_path,
+            )
 
     def volume(self) -> int:
         try:

--- a/src/core/caching/path_cache_ops.py
+++ b/src/core/caching/path_cache_ops.py
@@ -1,0 +1,45 @@
+import logging
+from collections.abc import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+def delete_cached_paths(
+    paths: Iterable[str],
+    *,
+    rating_cache=None,
+    exif_cache=None,
+) -> None:
+    """Invalidate path-keyed disk caches from a filesystem worker."""
+
+    for path in dict.fromkeys(path for path in paths if path):
+        if rating_cache is not None:
+            rating_cache.delete(path)
+        if exif_cache is not None:
+            exif_cache.delete(path)
+
+
+def migrate_cached_paths(
+    path_updates: dict[str, str] | Iterable[tuple[str, str]],
+    *,
+    rating_cache=None,
+    exif_cache=None,
+) -> None:
+    """Move disk-cache values to renamed path keys outside the UI thread."""
+
+    pairs = (
+        path_updates.items() if isinstance(path_updates, dict) else path_updates
+    )
+    for old_path, new_path in pairs:
+        if not old_path or not new_path or old_path == new_path:
+            continue
+        if rating_cache is not None:
+            rating = rating_cache.get(old_path)
+            if rating is not None:
+                rating_cache.set(new_path, rating)
+                rating_cache.delete(old_path)
+        if exif_cache is not None:
+            metadata = exif_cache.get(old_path)
+            if metadata is not None:
+                exif_cache.set(new_path, metadata)
+                exif_cache.delete(old_path)

--- a/src/core/caching/path_cache_ops.py
+++ b/src/core/caching/path_cache_ops.py
@@ -27,9 +27,7 @@ def migrate_cached_paths(
 ) -> None:
     """Move disk-cache values to renamed path keys outside the UI thread."""
 
-    pairs = (
-        path_updates.items() if isinstance(path_updates, dict) else path_updates
-    )
+    pairs = path_updates.items() if isinstance(path_updates, dict) else path_updates
     for old_path, new_path in pairs:
         if not old_path or not new_path or old_path == new_path:
             continue

--- a/src/core/grouping.py
+++ b/src/core/grouping.py
@@ -70,6 +70,8 @@ class GroupingPlan:
     # worker has already included non-media files that need to move with it.
     filesystem_inventory_complete: bool = False
     source_root: str = ""
+    filesystem_paths: set[str] = field(default_factory=set)
+    filesystem_directories: set[str] = field(default_factory=set)
 
     def to_preview(self) -> GroupingPreview:
         return GroupingPreview(
@@ -181,16 +183,37 @@ def augment_grouping_plan_with_filesystem_paths(
                 continue
         return False
 
-    discovered_paths: list[str] = []
-    for walk_root in walk_roots:
-        for current_root, _dirnames, filenames in os.walk(walk_root):
-            for filename in filenames:
-                # XMP files follow the separate companion-file preference.
-                if os.path.splitext(filename)[1].lower() == ".xmp":
-                    continue
-                path = os.path.join(current_root, filename)
-                if not is_pending_deletion(path):
-                    discovered_paths.append(path)
+    inventory_paths: set[str] = set()
+    inventory_directories: set[str] = {root}
+    for current_root, dirnames, filenames in os.walk(root):
+        inventory_directories.update(
+            os.path.join(current_root, dirname) for dirname in dirnames
+        )
+        inventory_paths.update(
+            os.path.join(current_root, filename) for filename in filenames
+        )
+    plan.filesystem_paths = inventory_paths
+    plan.filesystem_directories = inventory_directories
+
+    normalized_walk_roots = [
+        os.path.normcase(os.path.normpath(value)) for value in walk_roots
+    ]
+
+    def is_in_walk_roots(path: str) -> bool:
+        normalized_path = os.path.normcase(os.path.normpath(path))
+        return any(
+            normalized_path == walk_root
+            or normalized_path.startswith(walk_root + os.sep)
+            for walk_root in normalized_walk_roots
+        )
+
+    discovered_paths = [
+        path
+        for path in inventory_paths
+        if is_in_walk_roots(path)
+        and os.path.splitext(path)[1].lower() != ".xmp"
+        and not is_pending_deletion(path)
+    ]
 
     normalized_planned = {
         os.path.normcase(os.path.normpath(path)) for path in planned_paths

--- a/src/core/metadata_processor.py
+++ b/src/core/metadata_processor.py
@@ -588,7 +588,9 @@ class MetadataProcessor:
                     )
             final_results_for_caller[cache_key] = {
                 "rating": parsed_rating,
+                "label": parsed_label,
                 "date": parsed_date,
+                "raw_metadata": raw_metadata,
             }
             if idx == 1 or idx % DETAIL_LOG_INTERVAL == 0 or idx == total_result_count:
                 logger.debug(

--- a/src/ui/advanced_image_viewer.py
+++ b/src/ui/advanced_image_viewer.py
@@ -1158,9 +1158,7 @@ class IndividualViewer(QWidget):
         normalized_path = os.path.normpath(self._file_path)
         try:
             if os.name == "nt":
-                QProcess.startDetached(
-                    "explorer", ["/select,", normalized_path]
-                )
+                QProcess.startDetached("explorer", ["/select,", normalized_path])
             elif os.name == "posix":
                 if os.uname().sysname == "Darwin":
                     QProcess.startDetached("open", ["-R", normalized_path])

--- a/src/ui/advanced_image_viewer.py
+++ b/src/ui/advanced_image_viewer.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import subprocess
 from typing import Any, override
 from PyQt6.QtCore import (
     QEasingCurve,
@@ -10,6 +9,7 @@ from PyQt6.QtCore import (
     pyqtSignal,
     QTimer,
     QPoint,
+    QProcess,
     QUrl,
     QEvent,
     QObject,
@@ -1158,13 +1158,15 @@ class IndividualViewer(QWidget):
         normalized_path = os.path.normpath(self._file_path)
         try:
             if os.name == "nt":
-                subprocess.run(["explorer", "/select,", normalized_path], check=False)
+                QProcess.startDetached(
+                    "explorer", ["/select,", normalized_path]
+                )
             elif os.name == "posix":
                 if os.uname().sysname == "Darwin":
-                    subprocess.run(["open", "-R", normalized_path], check=False)
+                    QProcess.startDetached("open", ["-R", normalized_path])
                 else:
-                    subprocess.run(
-                        ["xdg-open", os.path.dirname(normalized_path)], check=False
+                    QProcess.startDetached(
+                        "xdg-open", [os.path.dirname(normalized_path)]
                     )
         except Exception:
             logger.error(

--- a/src/ui/app_controller.py
+++ b/src/ui/app_controller.py
@@ -15,7 +15,6 @@ from core.app_settings import (
 from core.similarity_embedding_model import is_similarity_model_installed
 from core.media_utils import is_image_extension
 from core.image_file_ops import ImageFileOperations
-from core.pyexiv2_wrapper import PyExiv2Operations
 from core.grouping import build_grouping_output_root
 from core.similarity_utils import (
     adaptive_dbscan_eps,
@@ -158,6 +157,7 @@ class AppController(QObject):
         self._cancelled_workflows: set[str] = set()
         self._ignore_similarity_results = False
         self._pending_exif_cache_capacity_warning: tuple[int, int, int] | None = None
+        self._pending_folder_load: tuple[str, dict[str, bool]] | None = None
 
     def is_workflow_analysis_running(self, workflow: str) -> bool:
         if workflow == "organize":
@@ -377,6 +377,14 @@ class AppController(QObject):
                 4000,
             )
             return
+        if getattr(
+            self.worker_manager, "is_file_deletion_running", lambda: False
+        )():
+            self.main_window.statusBar().showMessage(
+                "Files are still moving to Trash. Wait before loading another folder.",
+                4000,
+            )
+            return
 
         marked_files = self.app_state.get_marked_files()
         preserved_marks = set(marked_files) if preserve_deletion_marks else set()
@@ -391,7 +399,20 @@ class AppController(QObject):
                     "User chose to commit deletions before switching folders (%d files).",
                     len(marked_files),
                 )
-                self.main_window._commit_marked_deletions_without_confirmation()
+                self._pending_folder_load = (
+                    folder_path,
+                    {
+                        "skip_grouping_step": skip_grouping_step,
+                        "record_as_source": record_as_source,
+                        "preserve_deletion_marks": preserve_deletion_marks,
+                    },
+                )
+                started = (
+                    self.main_window._commit_marked_deletions_without_confirmation()
+                )
+                if started is False:
+                    self._pending_folder_load = None
+                return
             elif choice == "ignore":
                 logger.info(
                     "User chose to ignore %d marked deletions before switching folders.",
@@ -471,6 +492,34 @@ class AppController(QObject):
             blur_threshold=self.main_window.blur_detection_threshold,
         )
 
+    def resume_folder_load_after_deletion(self, successful: bool) -> None:
+        pending = self._pending_folder_load
+        if pending is None:
+            return
+        if not successful:
+            self._pending_folder_load = None
+            self.main_window.statusBar().showMessage(
+                "Folder change cancelled because some items could not be moved to Trash.",
+                5000,
+            )
+            return
+        self._finish_pending_folder_load()
+
+    def _finish_pending_folder_load(self) -> None:
+        """Resume a deferred folder load after the deletion thread has exited."""
+        if getattr(
+            self.worker_manager, "is_file_deletion_running", lambda: False
+        )():
+            QTimer.singleShot(25, self._finish_pending_folder_load)
+            return
+
+        pending = self._pending_folder_load
+        self._pending_folder_load = None
+        if pending is None:
+            return
+        folder_path, options = pending
+        self.load_folder(folder_path, **options)
+
     def start_similarity_analysis(self):
         self._ignore_similarity_results = False
         logger.info("Starting similarity analysis.")
@@ -543,6 +592,8 @@ class AppController(QObject):
         self.worker_manager.start_similarity_analysis(
             paths_for_similarity,
             allow_model_download=allow_model_download,
+            folder_path=getattr(self.app_state, "current_folder_path", None),
+            analysis_cache=getattr(self.app_state, "analysis_cache", None),
         )
 
     def refresh_grouping_preview(self):
@@ -622,6 +673,9 @@ class AppController(QObject):
             prepared_plan=prepared_plan,
             location_depth=self.main_window.grouping_step_widget.get_location_depth(),
             move_companions=get_companion_files_preference() == "always",
+            rating_cache=self.app_state.rating_disk_cache,
+            exif_cache=self.app_state.exif_disk_cache,
+            analysis_cache=self.app_state.analysis_cache,
         )
 
     def start_blur_detection_analysis(self):
@@ -933,13 +987,6 @@ class AppController(QObject):
 
         cluster_map = self._build_cluster_path_map()
         existing_clusters = set(self.app_state.best_shot_rankings.keys())
-        if not existing_clusters and self.app_state.current_folder_path:
-            cached_clusters = (
-                self.app_state.analysis_cache.get_completed_best_shot_clusters(
-                    self.app_state.current_folder_path
-                )
-            )
-            existing_clusters.update(cached_clusters)
         if existing_clusters:
             cluster_map = {
                 cid: paths
@@ -1037,6 +1084,12 @@ class AppController(QObject):
                 "AI rating is already running.", 3000
             )
             return
+        if self.worker_manager.is_rating_loader_running():
+            self.main_window.statusBar().showMessage(
+                "Metadata is still loading. AI rating will be available when it finishes.",
+                4000,
+            )
+            return
 
         if not self.app_state.image_files_data:
             self.main_window.statusBar().showMessage("No images loaded to rate.", 3000)
@@ -1089,21 +1142,6 @@ class AppController(QObject):
                     return
         self.main_window.statusBar().showMessage("No folder context to reload.", 3000)
 
-    def move_to_trash(self, file_path: str):
-        """Moves a file to the system's trash."""
-        logger.info(f"Moving file to trash: {os.path.basename(file_path)}")
-        success, message = ImageFileOperations.move_to_trash(file_path)
-        if not success:
-            logger.error(
-                f"Failed to move file to trash: {os.path.basename(file_path)} - {message}"
-            )
-            self.main_window.statusBar().showMessage(message, 5000)
-        else:
-            logger.info(
-                f"Successfully moved file to trash: {os.path.basename(file_path)}"
-            )
-        return success, message
-
     def rename_image(self, old_path: str, new_path: str):
         """Renames an image file."""
         success, message = ImageFileOperations.rename_image(old_path, new_path)
@@ -1153,81 +1191,17 @@ class AppController(QObject):
     def _filter_image_paths(self, paths: list[str]) -> list[str]:
         return [path for path in paths if path and is_image_extension(path)]
 
-    def _get_existing_rating_for_path(self, image_path: str) -> int | None:
-        normalized_path = os.path.normpath(image_path)
-        cached_rating = self._get_cached_rating(normalized_path)
-        if cached_rating is not None:
-            return cached_rating
-
-        metadata_rating = self._read_metadata_rating(normalized_path)
-        if metadata_rating is None:
-            self._cache_missing_rating(normalized_path)
-            return None
-
-        rating_int = self._normalize_rating_value(metadata_rating, normalized_path)
-        if rating_int is None:
-            return None
-
-        self._cache_rating(normalized_path, rating_int)
-        return rating_int
-
-    def _get_cached_rating(self, normalized_path: str) -> int | None:
-        cached_rating = self.app_state.rating_cache.get(normalized_path)
-        if cached_rating is not None:
-            return int(cached_rating)
-        disk_cache = getattr(self.app_state, "rating_disk_cache", None)
-        if disk_cache:
-            disk_rating = disk_cache.get(normalized_path)
-            if disk_rating is not None:
-                rating_int = int(disk_rating)
-                self.app_state.rating_cache[normalized_path] = rating_int
-                return rating_int
-        return None
-
-    def _read_metadata_rating(self, normalized_path: str) -> float | None:
-        try:
-            return PyExiv2Operations.get_rating(normalized_path)
-        except Exception:
-            logger.debug(
-                "Failed to read rating metadata for %s",
-                normalized_path,
-                exc_info=True,
-            )
-            return None
-
-    def _normalize_rating_value(
-        self, metadata_rating: object, normalized_path: str
-    ) -> int | None:
-        try:
-            rating_int = int(round(float(metadata_rating)))
-        except TypeError, ValueError:
-            logger.debug(
-                "Unexpected rating value for %s: %s",
-                normalized_path,
-                metadata_rating,
-            )
-            return None
-        return max(0, min(5, rating_int))
-
-    def _cache_rating(self, normalized_path: str, rating: int) -> None:
-        self.app_state.rating_cache[normalized_path] = rating
-        disk_cache = getattr(self.app_state, "rating_disk_cache", None)
-        if disk_cache:
-            disk_cache.set(normalized_path, rating)
-
-    def _cache_missing_rating(self, normalized_path: str) -> None:
-        self.app_state.rating_cache.setdefault(normalized_path, 0)
-        disk_cache = getattr(self.app_state, "rating_disk_cache", None)
-        if disk_cache:
-            disk_cache.set(normalized_path, 0)
-
     def _partition_unrated_images(
         self, image_paths: list[str]
     ) -> tuple[list[str], int]:
+        """Partition from the worker-populated memory cache only."""
+
         unrated: list[str] = []
         already_rated_count = 0
         for path in image_paths:
-            existing_rating = self._get_existing_rating_for_path(path)
+            existing_rating = self.app_state.rating_cache.get(
+                os.path.normpath(path), 0
+            )
             if existing_rating is not None and existing_rating != 0:
                 already_rated_count += 1
                 continue
@@ -1256,7 +1230,10 @@ class AppController(QObject):
         self.main_window.menu_manager.detect_blur_action.setEnabled(has_images)
         self.main_window.menu_manager.auto_rotate_action.setEnabled(has_images)
         self.main_window.menu_manager.group_by_similarity_action.setEnabled(has_images)
-        self.main_window.menu_manager.ai_rate_images_action.setEnabled(has_images)
+        # Rating decisions depend on the background metadata pass. Enabling AI
+        # rating before it finishes would force per-file disk/EXIF reads from
+        # the UI thread to discover already-rated images.
+        self.main_window.menu_manager.ai_rate_images_action.setEnabled(False)
 
         self._restore_analysis_state()
         if self._supports_grouping_workflow_ui():
@@ -1384,16 +1361,21 @@ class AppController(QObject):
         )
 
     def handle_grouping_workflow_complete(self, summary):
-        for entry in getattr(summary, "entries", []):
-            if getattr(entry, "new_path", None):
-                try:
-                    self.app_state.update_path(entry.original_path, entry.new_path)
-                except Exception:
-                    logger.debug(
-                        "Failed to update in-memory path cache for %s",
-                        entry.original_path,
-                        exc_info=True,
-                    )
+        path_updates = {
+            entry.original_path: entry.new_path
+            for entry in getattr(summary, "entries", [])
+            if getattr(entry, "new_path", None)
+        }
+        try:
+            self.app_state.update_paths(
+                path_updates,
+                migrate_disk_caches=False,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to update in-memory path caches after grouping.",
+                exc_info=True,
+            )
         self.app_state.grouping_run_summary = {
             "mode": summary.mode,
             "output_root": summary.output_root,
@@ -1726,6 +1708,10 @@ class AppController(QObject):
 
         self.main_window.hide_loading_overlay()
         self.main_window.hide_exif_progress()
+        menu_manager = getattr(self.main_window, "menu_manager", None)
+        ai_rating_action = getattr(menu_manager, "ai_rate_images_action", None)
+        if ai_rating_action is not None:
+            ai_rating_action.setEnabled(bool(self._get_image_file_data()))
 
         warning = self._pending_exif_cache_capacity_warning
         self._pending_exif_cache_capacity_warning = None
@@ -1807,18 +1793,6 @@ class AppController(QObject):
         self.app_state.clear_best_shot_results()
         self.app_state.clear_pick_best_results()
 
-        # Apply saved manual overrides on top of auto-clustering results
-        if self.app_state.current_folder_path:
-            manual_overrides = self.app_state.analysis_cache.get_manual_overrides(
-                self.app_state.current_folder_path
-            )
-            for path, cluster_id in manual_overrides.items():
-                if path in self.app_state.cluster_results:
-                    self.app_state.cluster_results[path] = cluster_id
-
-            self.app_state.analysis_cache.save_cluster_results(
-                self.app_state.current_folder_path, self.app_state.cluster_results
-            )
         self.main_window.menu_manager.analyze_similarity_action.setEnabled(
             bool(self._get_image_file_data())
         )
@@ -1910,13 +1884,6 @@ class AppController(QObject):
         new_results = rankings_by_cluster or {}
         if new_results:
             self.app_state.merge_best_shot_results(new_results)
-            if self.app_state.current_folder_path:
-                for cluster_id, rankings in new_results.items():
-                    self.app_state.analysis_cache.update_best_shot_results(
-                        self.app_state.current_folder_path,
-                        cluster_id,
-                        rankings,
-                    )
         self.main_window.hide_loading_overlay()
         analyzed = len(new_results)
         self.main_window.statusBar().showMessage(
@@ -1992,13 +1959,6 @@ class AppController(QObject):
 
             ratings_applied += 1
             self.app_state.rating_cache[image_path] = rating_int
-            if self.app_state.rating_disk_cache:
-                try:
-                    self.app_state.rating_disk_cache.set(image_path, rating_int)
-                except Exception:  # pragma: no cover - cache writes should not crash UI
-                    logger.exception(
-                        "Failed to persist AI rating cache for %s", image_path
-                    )
 
             for viewer in self.main_window.advanced_image_viewer.image_viewers:
                 if viewer.isVisible() and viewer._file_path == image_path:

--- a/src/ui/app_controller.py
+++ b/src/ui/app_controller.py
@@ -377,9 +377,7 @@ class AppController(QObject):
                 4000,
             )
             return
-        if getattr(
-            self.worker_manager, "is_file_deletion_running", lambda: False
-        )():
+        if getattr(self.worker_manager, "is_file_deletion_running", lambda: False)():
             self.main_window.statusBar().showMessage(
                 "Files are still moving to Trash. Wait before loading another folder.",
                 4000,
@@ -507,9 +505,7 @@ class AppController(QObject):
 
     def _finish_pending_folder_load(self) -> None:
         """Resume a deferred folder load after the deletion thread has exited."""
-        if getattr(
-            self.worker_manager, "is_file_deletion_running", lambda: False
-        )():
+        if getattr(self.worker_manager, "is_file_deletion_running", lambda: False)():
             QTimer.singleShot(25, self._finish_pending_folder_load)
             return
 
@@ -1199,9 +1195,7 @@ class AppController(QObject):
         unrated: list[str] = []
         already_rated_count = 0
         for path in image_paths:
-            existing_rating = self.app_state.rating_cache.get(
-                os.path.normpath(path), 0
-            )
+            existing_rating = self.app_state.rating_cache.get(os.path.normpath(path), 0)
             if existing_rating is not None and existing_rating != 0:
                 already_rated_count += 1
                 continue

--- a/src/ui/app_state.py
+++ b/src/ui/app_state.py
@@ -311,6 +311,11 @@ class AppState:
         if not updates:
             return 0
 
+        def remap_optional_path(path: object) -> object:
+            if isinstance(path, str):
+                return updates.get(path, path)
+            return path
+
         for record in self._image_files_data:
             old_path = record.get("path")
             if old_path in updates:
@@ -371,9 +376,7 @@ class AppState:
             self.easy_delete_results = {
                 updates.get(path, path): {
                     **entry,
-                    "pair_path": updates.get(
-                        entry.get("pair_path"), entry.get("pair_path")
-                    ),
+                    "pair_path": remap_optional_path(entry.get("pair_path")),
                 }
                 for path, entry in self.easy_delete_results.items()
             }
@@ -386,11 +389,13 @@ class AppState:
             winner_path = cluster.get("winner_path")
             if winner_path in updates:
                 cluster["winner_path"] = updates[winner_path]
-            for field in ("all_paths", "unsupported_paths"):
-                cluster[field] = [
-                    updates.get(path, path) for path in cluster.get(field, [])
-                ]
-            for entries in (cluster.get("ranked", []), cluster.get("failed", [])):
+            cluster["all_paths"] = [
+                updates.get(path, path) for path in cluster["all_paths"]
+            ]
+            cluster["unsupported_paths"] = [
+                updates.get(path, path) for path in cluster["unsupported_paths"]
+            ]
+            for entries in (cluster["ranked"], cluster["failed"]):
                 for score_entry in entries:
                     path = score_entry.get("path")
                     if path in updates:

--- a/src/ui/app_state.py
+++ b/src/ui/app_state.py
@@ -298,11 +298,7 @@ class AppState:
     ) -> int:
         """Rename references with one pass over each shared result collection."""
 
-        pairs = (
-            path_updates.items()
-            if isinstance(path_updates, dict)
-            else path_updates
-        )
+        pairs = path_updates.items() if isinstance(path_updates, dict) else path_updates
         updates = {
             old_path: new_path
             for old_path, new_path in pairs

--- a/src/ui/app_state.py
+++ b/src/ui/app_state.py
@@ -36,6 +36,7 @@ class AppState:
             str, int
         ] = {}  # This is an in-memory dictionary for quick UI access
         self.date_cache: dict[str, datetime_obj | None] = {}
+        self.detailed_metadata_cache: dict[str, dict[str, Any]] = {}
         self.cluster_results: dict[str, int] = {}  # {image_path: cluster_id}
         self.embeddings_cache: dict[
             str, list[float]
@@ -141,6 +142,7 @@ class AppState:
         self.image_files_data = []
         self.rating_cache.clear()  # Clears in-memory dict
         self.date_cache.clear()
+        self.detailed_metadata_cache.clear()
         self.cluster_results.clear()
         self.embeddings_cache.clear()
         self.regional_embeddings_cache.clear()
@@ -160,53 +162,104 @@ class AppState:
         # self.current_folder_path = None # Optionally reset current folder path
 
     def remove_data_for_path(self, file_path: str):
-        """Removes all cached data associated with a specific file path."""
-        logger.info(f"Removing all cached data for file: {os.path.basename(file_path)}")
+        """Remove one path while preserving the batch implementation as owner."""
 
-        original_count = len(self.image_files_data)
-        self.image_files_data = [
-            fd for fd in self.image_files_data if fd.get("path") != file_path
+        self.remove_data_for_paths([file_path])
+
+    def remove_data_for_paths(
+        self,
+        file_paths: Iterable[str],
+        *,
+        clear_disk_caches: bool = True,
+    ) -> int:
+        """Remove file-scoped state in one pass over every shared structure.
+
+        ``clear_disk_caches`` is disabled when a filesystem worker already
+        invalidated the disk caches. Keeping that I/O off the UI thread is
+        important for large deletion batches.
+        """
+
+        removed_paths = {path for path in file_paths if isinstance(path, str) and path}
+        if not removed_paths:
+            return 0
+
+        original_count = len(self._image_files_data)
+        self._image_files_data = [
+            record
+            for record in self._image_files_data
+            if record.get("path") not in removed_paths
         ]
-        removed_from_image_files = original_count - len(self.image_files_data)
+        self._rebuild_media_index()
 
-        rating_removed = self.rating_cache.pop(file_path, None)  # In-memory dict
-        if self.rating_disk_cache:
-            self.rating_disk_cache.delete(file_path)  # Disk cache
-        if self.exif_disk_cache:
-            self.exif_disk_cache.delete(file_path)  # Exif Disk cache
-        date_removed = self.date_cache.pop(file_path, None)
-        cluster_removed = self.cluster_results.pop(file_path, None)
-        embedding_removed = self.embeddings_cache.pop(file_path, None)
-        self.regional_embeddings_cache.pop(file_path, None)
-        removed_best = self.best_shot_scores_by_path.pop(file_path, None)
-        if cluster_removed is None and removed_best:
-            cluster_removed = removed_best.get("cluster_id")
-        if cluster_removed is not None:
-            rankings = self.best_shot_rankings.get(cluster_removed)
-            if rankings:
-                self.best_shot_rankings[cluster_removed] = [
-                    r for r in rankings if r.get("image_path") != file_path
-                ]
-                if not self.best_shot_rankings[cluster_removed]:
-                    self.best_shot_rankings.pop(cluster_removed, None)
-            winner = self.best_shot_winners.get(cluster_removed)
-            if winner and winner.get("image_path") == file_path:
-                self.best_shot_winners.pop(cluster_removed, None)
+        for cache in (
+            self.rating_cache,
+            self.date_cache,
+            self.detailed_metadata_cache,
+            self.cluster_results,
+            self.embeddings_cache,
+            self.regional_embeddings_cache,
+            self.best_shot_scores_by_path,
+            self.ai_rating_results,
+        ):
+            for path in removed_paths:
+                cache.pop(path, None)
 
-        self.ai_rating_results.pop(file_path, None)
-        self.marked_for_deletion.discard(file_path)
-        if self.focused_image_path == file_path:
+        if clear_disk_caches:
+            for path in removed_paths:
+                if self.rating_disk_cache:
+                    self.rating_disk_cache.delete(path)
+                if self.exif_disk_cache:
+                    self.exif_disk_cache.delete(path)
+
+        for cluster_id, rankings in list(self.best_shot_rankings.items()):
+            retained = [
+                entry
+                for entry in rankings
+                if entry.get("image_path") not in removed_paths
+            ]
+            if retained:
+                self.best_shot_rankings[cluster_id] = retained
+            else:
+                self.best_shot_rankings.pop(cluster_id, None)
+        for cluster_id, winner in list(self.best_shot_winners.items()):
+            if winner.get("image_path") in removed_paths:
+                self.best_shot_winners.pop(cluster_id, None)
+
+        self.marked_for_deletion.difference_update(removed_paths)
+        if self.focused_image_path in removed_paths:
             self.focused_image_path = None
-        self._remove_path_from_workflow_results(file_path)
 
-        logger.debug(
-            f"Removed data for {os.path.basename(file_path)}: "
-            f"image_files_data={removed_from_image_files}, "
-            f"rating_cache={rating_removed is not None}, "
-            f"date_cache={date_removed is not None}, "
-            f"cluster_results={cluster_removed is not None}, "
-            f"embeddings_cache={embedding_removed is not None}"
+        if self.easy_delete_results is not None:
+            self.easy_delete_results = {
+                path: entry
+                for path, entry in self.easy_delete_results.items()
+                if path not in removed_paths
+                and entry.get("pair_path") not in removed_paths
+            }
+        if self.fix_rotation_results is not None:
+            self.fix_rotation_results = {
+                path: angle
+                for path, angle in self.fix_rotation_results.items()
+                if path not in removed_paths
+            }
+
+        invalid_pick_best_paths: set[str] = set()
+        for cluster_id, cluster in list(self.pick_best_results.items()):
+            cluster_paths = set(cluster.get("all_paths", []))
+            if cluster_paths.intersection(removed_paths):
+                invalid_pick_best_paths.update(cluster_paths)
+                self.pick_best_results.pop(cluster_id, None)
+        invalid_pick_best_paths.update(removed_paths)
+        for path in invalid_pick_best_paths:
+            self.pick_best_winners_by_path.pop(path, None)
+
+        removed_count = original_count - len(self._image_files_data)
+        logger.info(
+            "Removed shared data for %d path(s) in one batch (%d media records).",
+            len(removed_paths),
+            removed_count,
         )
+        return removed_count
 
     def _remove_path_from_workflow_results(self, file_path: str) -> None:
         """Invalidate analysis results that can no longer be reviewed safely."""
@@ -233,98 +286,131 @@ class AppState:
         self.pick_best_winners_by_path.pop(file_path, None)
 
     def update_path(self, old_path: str, new_path: str):
-        """Updates all cache entries and data references from an old path to a new path."""
-        # Update image_files_data
-        file_data = self.get_file_data_by_path(old_path)
-        if file_data:
-            file_data["path"] = new_path
-            self._file_data_by_path.pop(old_path, None)
-            self._file_data_by_path[new_path] = file_data
+        """Update one path while preserving the batch implementation as owner."""
 
-        # Update in-memory caches
-        if old_path in self.rating_cache:
-            self.rating_cache[new_path] = self.rating_cache.pop(old_path)
-        if old_path in self.date_cache:
-            self.date_cache[new_path] = self.date_cache.pop(old_path)
-        if old_path in self.cluster_results:
-            self.cluster_results[new_path] = self.cluster_results.pop(old_path)
-        if old_path in self.embeddings_cache:
-            self.embeddings_cache[new_path] = self.embeddings_cache.pop(old_path)
-        if old_path in self.regional_embeddings_cache:
-            self.regional_embeddings_cache[new_path] = (
-                self.regional_embeddings_cache.pop(old_path)
-            )
-        if old_path in self.best_shot_scores_by_path:
-            self.best_shot_scores_by_path[new_path] = self.best_shot_scores_by_path.pop(
-                old_path
-            )
-        for ranking in self.best_shot_rankings.values():
-            for result in ranking:
-                if result.get("image_path") == old_path:
-                    result["image_path"] = new_path
-        for winner in self.best_shot_winners.values():
-            if winner.get("image_path") == old_path:
-                winner["image_path"] = new_path
-        if old_path in self.ai_rating_results:
-            self.ai_rating_results[new_path] = self.ai_rating_results.pop(old_path)
+        self.update_paths({old_path: new_path})
 
-        # Update disk caches
-        if self.rating_disk_cache:
-            rating_val = self.rating_disk_cache.get(old_path)
-            if rating_val is not None:
-                self.rating_disk_cache.set(new_path, rating_val)
-                self.rating_disk_cache.delete(old_path)
+    def update_paths(
+        self,
+        path_updates: dict[str, str] | Iterable[tuple[str, str]],
+        *,
+        migrate_disk_caches: bool = True,
+    ) -> int:
+        """Rename references with one pass over each shared result collection."""
 
-        if self.exif_disk_cache:
-            exif_data = self.exif_disk_cache.get(old_path)
-            if exif_data is not None:
-                self.exif_disk_cache.set(new_path, exif_data)
-                self.exif_disk_cache.delete(old_path)
+        pairs = (
+            path_updates.items()
+            if isinstance(path_updates, dict)
+            else path_updates
+        )
+        updates = {
+            old_path: new_path
+            for old_path, new_path in pairs
+            if isinstance(old_path, str)
+            and isinstance(new_path, str)
+            and old_path
+            and new_path
+            and old_path != new_path
+        }
+        if not updates:
+            return 0
 
-        if self.focused_image_path == old_path:
-            self.focused_image_path = new_path
-        if self.easy_delete_results is not None:
-            easy_entry = self.easy_delete_results.pop(old_path, None)
-            if easy_entry is not None:
-                self.easy_delete_results[new_path] = easy_entry
-            for easy_delete_entry in self.easy_delete_results.values():
-                if easy_delete_entry.get("pair_path") == old_path:
-                    easy_delete_entry["pair_path"] = new_path
-        if (
-            self.fix_rotation_results is not None
-            and old_path in self.fix_rotation_results
+        for record in self._image_files_data:
+            old_path = record.get("path")
+            if old_path in updates:
+                record["path"] = updates[old_path]
+        self._file_data_by_path = {
+            record["path"]: record
+            for record in self._image_files_data
+            if record.get("path")
+        }
+
+        def remap_keys(cache: dict) -> None:
+            moved = [
+                (updates[path], cache.pop(path))
+                for path in tuple(updates)
+                if path in cache
+            ]
+            cache.update(moved)
+
+        for cache in (
+            self.rating_cache,
+            self.date_cache,
+            self.detailed_metadata_cache,
+            self.cluster_results,
+            self.embeddings_cache,
+            self.regional_embeddings_cache,
+            self.best_shot_scores_by_path,
+            self.ai_rating_results,
+            self.pick_best_winners_by_path,
         ):
-            self.fix_rotation_results[new_path] = self.fix_rotation_results.pop(
-                old_path
-            )
+            remap_keys(cache)
+
+        for rankings in self.best_shot_rankings.values():
+            for result in rankings:
+                path = result.get("image_path")
+                if path in updates:
+                    result["image_path"] = updates[path]
+        for winner in self.best_shot_winners.values():
+            path = winner.get("image_path")
+            if path in updates:
+                winner["image_path"] = updates[path]
+
+        if migrate_disk_caches:
+            for old_path, new_path in updates.items():
+                if self.rating_disk_cache:
+                    rating_val = self.rating_disk_cache.get(old_path)
+                    if rating_val is not None:
+                        self.rating_disk_cache.set(new_path, rating_val)
+                        self.rating_disk_cache.delete(old_path)
+                if self.exif_disk_cache:
+                    exif_data = self.exif_disk_cache.get(old_path)
+                    if exif_data is not None:
+                        self.exif_disk_cache.set(new_path, exif_data)
+                        self.exif_disk_cache.delete(old_path)
+
+        if self.focused_image_path in updates:
+            self.focused_image_path = updates[self.focused_image_path]
+        if self.easy_delete_results is not None:
+            self.easy_delete_results = {
+                updates.get(path, path): {
+                    **entry,
+                    "pair_path": updates.get(
+                        entry.get("pair_path"), entry.get("pair_path")
+                    ),
+                }
+                for path, entry in self.easy_delete_results.items()
+            }
+        if self.fix_rotation_results is not None:
+            self.fix_rotation_results = {
+                updates.get(path, path): angle
+                for path, angle in self.fix_rotation_results.items()
+            }
         for cluster in self.pick_best_results.values():
-            if cluster.get("winner_path") == old_path:
-                cluster["winner_path"] = new_path
-            cluster["all_paths"] = [
-                new_path if path == old_path else path
-                for path in cluster.get("all_paths", [])
-            ]
-            cluster["unsupported_paths"] = [
-                new_path if path == old_path else path
-                for path in cluster.get("unsupported_paths", [])
-            ]
-            for entries in (
-                cluster.get("ranked", []),
-                cluster.get("failed", []),
-            ):
+            winner_path = cluster.get("winner_path")
+            if winner_path in updates:
+                cluster["winner_path"] = updates[winner_path]
+            for field in ("all_paths", "unsupported_paths"):
+                cluster[field] = [
+                    updates.get(path, path) for path in cluster.get(field, [])
+                ]
+            for entries in (cluster.get("ranked", []), cluster.get("failed", [])):
                 for score_entry in entries:
-                    if score_entry.get("path") == old_path:
-                        score_entry["path"] = new_path
+                    path = score_entry.get("path")
+                    if path in updates:
+                        score_entry["path"] = updates[path]
             mark_state = cluster.get("_mark_state")
-            if isinstance(mark_state, dict) and old_path in mark_state:
-                mark_state[new_path] = mark_state.pop(old_path)
-        if old_path in self.pick_best_winners_by_path:
-            self.pick_best_winners_by_path[new_path] = (
-                self.pick_best_winners_by_path.pop(old_path)
-            )
-        if old_path in self.marked_for_deletion:
-            self.marked_for_deletion.discard(old_path)
-            self.marked_for_deletion.add(new_path)
+            if isinstance(mark_state, dict):
+                cluster["_mark_state"] = {
+                    updates.get(path, path): marked
+                    for path, marked in mark_state.items()
+                }
+
+        self.marked_for_deletion = {
+            updates.get(path, path) for path in self.marked_for_deletion
+        }
+        logger.info("Updated shared references for %d renamed path(s).", len(updates))
+        return len(updates)
 
     # Add more methods as needed, e.g., to get specific data,
     # update blur status, etc.

--- a/src/ui/controllers/deletion_mark_controller.py
+++ b/src/ui/controllers/deletion_mark_controller.py
@@ -131,18 +131,13 @@ class DeletionMarkController:
         file_system_model,
         proxy_model,
     ) -> int:
-        count = 0
-        for p in paths:
-            if self._is_marked_func(p):
-                self.app_state.unmark_for_deletion(p)
-            else:
-                self.app_state.mark_for_deletion(p)
-            item, is_blurred = self._resolve_item(
-                p, find_proxy_index, file_system_model, proxy_model
-            )
-            self._update_item_presentation(item, p, is_blurred)
-            count += 1
-        return count
+        unique_paths = list(dict.fromkeys(path for path in paths if path))
+        self.set_paths_marked(
+            {path: not self._is_marked_func(path) for path in unique_paths},
+            file_system_model,
+            proxy_model,
+        )
+        return len(unique_paths)
 
     def mark_paths(
         self,
@@ -151,16 +146,14 @@ class DeletionMarkController:
         file_system_model,
         proxy_model,
     ) -> int:
-        count = 0
-        for p in paths:
-            if not self._is_marked_func(p):
-                self.app_state.mark_for_deletion(p)
-                count += 1
-            item, is_blurred = self._resolve_item(
-                p, find_proxy_index, file_system_model, proxy_model
-            )
-            self._update_item_presentation(item, p, is_blurred)
-        return count
+        unique_paths = list(dict.fromkeys(path for path in paths if path))
+        changed = sum(not self._is_marked_func(path) for path in unique_paths)
+        self.set_paths_marked(
+            dict.fromkeys(unique_paths, True),
+            file_system_model,
+            proxy_model,
+        )
+        return changed
 
     def unmark_paths(
         self,
@@ -169,16 +162,14 @@ class DeletionMarkController:
         file_system_model,
         proxy_model,
     ) -> int:
-        count = 0
-        for p in paths:
-            if self._is_marked_func(p):
-                self.app_state.unmark_for_deletion(p)
-                count += 1
-            item, is_blurred = self._resolve_item(
-                p, find_proxy_index, file_system_model, proxy_model
-            )
-            self._update_item_presentation(item, p, is_blurred)
-        return count
+        unique_paths = list(dict.fromkeys(path for path in paths if path))
+        changed = sum(self._is_marked_func(path) for path in unique_paths)
+        self.set_paths_marked(
+            dict.fromkeys(unique_paths, False),
+            file_system_model,
+            proxy_model,
+        )
+        return changed
 
     def set_paths_marked(
         self,
@@ -251,18 +242,16 @@ class DeletionMarkController:
         file_system_model,
         proxy_model,
     ) -> int:
-        count = 0
-        for p in collection_paths:
-            if p == keep_path:
-                continue
-            if not self._is_marked_func(p):
-                self.app_state.mark_for_deletion(p)
-                count += 1
-            item, is_blurred = self._resolve_item(
-                p, find_proxy_index, file_system_model, proxy_model
-            )
-            self._update_item_presentation(item, p, is_blurred)
-        return count
+        paths = list(
+            dict.fromkeys(path for path in collection_paths if path != keep_path)
+        )
+        changed = sum(not self._is_marked_func(path) for path in paths)
+        self.set_paths_marked(
+            dict.fromkeys(paths, True),
+            file_system_model,
+            proxy_model,
+        )
+        return changed
 
     def unmark_others_in_collection(
         self,
@@ -272,18 +261,16 @@ class DeletionMarkController:
         file_system_model,
         proxy_model,
     ) -> int:
-        count = 0
-        for p in collection_paths:
-            if p == keep_path:
-                continue
-            if self._is_marked_func(p):
-                self.app_state.unmark_for_deletion(p)
-                count += 1
-            item, is_blurred = self._resolve_item(
-                p, find_proxy_index, file_system_model, proxy_model
-            )
-            self._update_item_presentation(item, p, is_blurred)
-        return count
+        paths = list(
+            dict.fromkeys(path for path in collection_paths if path != keep_path)
+        )
+        changed = sum(self._is_marked_func(path) for path in paths)
+        self.set_paths_marked(
+            dict.fromkeys(paths, False),
+            file_system_model,
+            proxy_model,
+        )
+        return changed
 
     def clear_all_and_update(
         self,
@@ -294,12 +281,11 @@ class DeletionMarkController:
         marked_files = list(self.app_state.get_marked_files())
         if not marked_files:
             return 0
-        self.app_state.clear_all_deletion_marks()
-        for p in marked_files:
-            item, is_blurred = self._resolve_item(
-                p, find_proxy_index, file_system_model, proxy_model
-            )
-            self._update_item_presentation(item, p, is_blurred)
+        self.set_paths_marked(
+            dict.fromkeys(marked_files, False),
+            file_system_model,
+            proxy_model,
+        )
         return len(marked_files)
 
     def update_blur_status(

--- a/src/ui/controllers/file_deletion_controller.py
+++ b/src/ui/controllers/file_deletion_controller.py
@@ -80,9 +80,7 @@ class FileDeletionController:
         start_batch = getattr(self.ctx, "_start_deletion_batch", None)
         if not callable(start_batch):
             logger.error("Background deletion service is unavailable.")
-            self.ctx.statusBar().showMessage(
-                "Deletion service is unavailable.", 3000
-            )
+            self.ctx.statusBar().showMessage("Deletion service is unavailable.", 3000)
             return
 
         started = start_batch(
@@ -102,9 +100,7 @@ class FileDeletionController:
             ),
         )
         if not started:
-            self.ctx.statusBar().showMessage(
-                "A deletion is already in progress.", 3000
-            )
+            self.ctx.statusBar().showMessage("A deletion is already in progress.", 3000)
 
     def _finish_background_delete(
         self,
@@ -130,8 +126,7 @@ class FileDeletionController:
             self.ctx._update_image_info_label()
         if failures:
             self.ctx.statusBar().showMessage(
-                f"{len(successful_targets)} moved to Trash; "
-                f"{len(failures)} failed.",
+                f"{len(successful_targets)} moved to Trash; {len(failures)} failed.",
                 5000,
             )
             show_error = getattr(self.ctx.dialog_manager, "show_error_dialog", None)

--- a/src/ui/controllers/file_deletion_controller.py
+++ b/src/ui/controllers/file_deletion_controller.py
@@ -77,79 +77,75 @@ class FileDeletionController:
         if not self.ctx.dialog_manager.show_confirm_delete_dialog(target_paths):
             return
 
-        source_indices = self._collect_source_indices(target_paths)
-        deleted_count, parent_items = self._delete_indices(source_indices)
-
-        if deleted_count > 0:
-            self._prune_empty_parent_groups(parent_items)
+        start_batch = getattr(self.ctx, "_start_deletion_batch", None)
+        if not callable(start_batch):
+            logger.error("Background deletion service is unavailable.")
             self.ctx.statusBar().showMessage(
-                f"{deleted_count} image(s) moved to trash.", 5000
+                "Deletion service is unavailable.", 3000
+            )
+            return
+
+        started = start_batch(
+            target_paths,
+            {path: [path] for path in target_paths},
+            completion=(
+                lambda successful_targets, deleted_paths, failures, _resolved: (
+                    self._finish_background_delete(
+                        view,
+                        visible_paths_before_delete,
+                        target_paths,
+                        successful_targets,
+                        deleted_paths,
+                        failures,
+                    )
+                )
+            ),
+        )
+        if not started:
+            self.ctx.statusBar().showMessage(
+                "A deletion is already in progress.", 3000
+            )
+
+    def _finish_background_delete(
+        self,
+        view: QAbstractItemView,
+        visible_paths_before_delete: list[str],
+        target_paths: list[str],
+        successful_targets: list[str],
+        deleted_paths: list[str],
+        failures: dict[str, str],
+    ) -> None:
+        if deleted_paths:
+            self.ctx.statusBar().showMessage(
+                f"{len(successful_targets)} image(s) moved to trash.", 5000
             )
             view.selectionModel().clearSelection()
             visible_after = self.ctx._get_all_visible_image_paths()
             self._restore_selection_after_delete(
-                visible_paths_before_delete, visible_after, target_paths, view
+                visible_paths_before_delete,
+                visible_after,
+                deleted_paths,
+                view,
             )
             self.ctx._update_image_info_label()
-        elif deleted_count == 0 and len(self.original_selection_paths) > 0:
+        if failures:
+            self.ctx.statusBar().showMessage(
+                f"{len(successful_targets)} moved to Trash; "
+                f"{len(failures)} failed.",
+                5000,
+            )
+            show_error = getattr(self.ctx.dialog_manager, "show_error_dialog", None)
+            if callable(show_error):
+                show_error(
+                    "Delete Error",
+                    f"Could not move {len(failures)} item(s) to Trash.",
+                )
+        elif not target_paths:
             self.ctx.statusBar().showMessage(
                 "No valid image files were deleted from selection.", 3000
             )
 
     # --- Internal helpers ---
-    def _collect_source_indices(self, paths: list[str]):
-        indices = []
-        for p in paths:
-            proxy = self.ctx._find_proxy_index_for_path(p)
-            if proxy.isValid():  # type: ignore[attr-defined]
-                src = self.ctx.proxy_model.mapToSource(proxy)
-                if src.isValid() and src not in indices:  # type: ignore[attr-defined]
-                    indices.append(src)
-        indices.sort(
-            key=lambda idx: (idx.parent().internalId(), idx.row()), reverse=True
-        )  # type: ignore[attr-defined]
-        return indices
-
-    def _delete_indices(self, source_indices):
-        deleted_count = 0
-        parent_items = []
-        for src_idx in source_indices:
-            item = self.ctx.file_system_model.itemFromIndex(src_idx)
-            if not item:
-                continue
-            data = item.data(0x0100)  # Qt.UserRole
-            if not isinstance(data, dict) or "path" not in data:
-                continue
-            path = data["path"]
-            if not os.path.isfile(path):
-                continue
-            try:
-                result = self.ctx.app_controller.move_to_trash(path)
-                if isinstance(result, tuple):
-                    success, message = result
-                else:
-                    success, message = bool(result), ""
-                if not success:
-                    raise RuntimeError(message)
-                self.ctx.app_state.remove_data_for_path(path)
-                parent_idx = src_idx.parent()
-                parent_item = (
-                    self.ctx.file_system_model.itemFromIndex(parent_idx)
-                    if parent_idx.isValid()
-                    else self.ctx.file_system_model.invisibleRootItem()
-                )
-                if parent_item:
-                    parent_item.takeRow(src_idx.row())
-                    if parent_item not in parent_items:
-                        parent_items.append(parent_item)
-                deleted_count += 1
-            except Exception as e:  # pragma: no cover (rare path)
-                logger.error("Error moving file to trash: %s", e, exc_info=True)
-                self.ctx.dialog_manager.show_error_dialog(
-                    "Delete Error", f"Could not move {os.path.basename(path)} to trash."
-                )
-        return deleted_count, parent_items
-
     def _prune_empty_parent_groups(self, parents):
         for parent_item_candidate in list(parents):
             if parent_item_candidate == self.ctx.file_system_model.invisibleRootItem():
@@ -165,7 +161,6 @@ class FileDeletionController:
                     or (
                         self.ctx.show_folders_mode
                         and not self.ctx.group_by_similarity_mode
-                        and os.path.isdir(user_data)
                     )
                 ):
                     is_eligible = True

--- a/src/ui/controllers/selection_controller.py
+++ b/src/ui/controllers/selection_controller.py
@@ -1,5 +1,4 @@
 from typing import Protocol, Any
-import os
 from PyQt6.QtCore import QModelIndex
 from PyQt6.QtGui import QStandardItem
 from PyQt6.QtCore import Qt
@@ -35,6 +34,7 @@ class SelectionController:
             return []
         selected_indexes = sel_model.selectedIndexes()
         out: list[str] = []
+        seen: set[str] = set()
         for proxy_index in selected_indexes:
             if proxy_index.column() != 0:
                 continue
@@ -47,7 +47,8 @@ class SelectionController:
             item_user_data = item.data(Qt.ItemDataRole.UserRole)
             if isinstance(item_user_data, dict) and "path" in item_user_data:
                 file_path = item_user_data["path"]
-                if os.path.isfile(file_path) and file_path not in out:
+                if file_path and file_path not in seen:
+                    seen.add(file_path)
                     out.append(file_path)
         return out
 

--- a/src/ui/dark_theme.qss
+++ b/src/ui/dark_theme.qss
@@ -223,11 +223,6 @@ QListView[viewMode="IconMode"]::item {
     text-align: center;
 }
 
-QTreeView::branch {
-    background: transparent;
-}
-
-
 /* --- Center Pane (Image and its Controls) --- */
 QWidget#center_pane_container {
     background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
@@ -2976,6 +2971,31 @@ QLabel#groupingTreeDesc {
     background: transparent;
 }
 
+QPushButton#groupingTreeControlButton {
+    background-color: transparent;
+    color: #8FA4B2;
+    border: 1px solid #3D474D;
+    border-radius: 6px;
+    padding: 3px 8px;
+    font-size: 8pt;
+    font-weight: 600;
+}
+
+QPushButton#groupingTreeControlButton:hover {
+    background-color: #30373B;
+    border-color: #58666E;
+    color: #D9E3EA;
+}
+
+QPushButton#groupingTreeControlButton:pressed {
+    background-color: #252B2E;
+}
+
+QPushButton#groupingTreeControlButton:disabled {
+    color: #4A565D;
+    border-color: #30373B;
+}
+
 /* The before panel header gets an amber left accent */
 QFrame#groupingBeforePanel QLabel#groupingTreeHeader {
     color: #D4A76A;
@@ -3016,10 +3036,6 @@ QTreeWidget#groupingTree::item:selected {
 QTreeWidget#groupingTree::item:hover:!selected {
     background-color: #2C3438;
     color: #D8E4EC;
-}
-
-QTreeWidget#groupingTree::branch {
-    background: transparent;
 }
 
 /* Bottom status bar */

--- a/src/ui/dialog_manager.py
+++ b/src/ui/dialog_manager.py
@@ -283,9 +283,7 @@ class DialogManager:
                     (("apply", "Apply rotations"), ("discard", "Discard queue")),
                 )
         if deletion_entries:
-            is_truncated = bool(
-                deletion_entries and deletion_entries[-1][0] == ""
-            )
+            is_truncated = bool(deletion_entries and deletion_entries[-1][0] == "")
             trash_heading = QLabel(
                 "Deletion targets"
                 if is_truncated

--- a/src/ui/dialog_manager.py
+++ b/src/ui/dialog_manager.py
@@ -90,6 +90,8 @@ def _build_kv_row(key_text, value_widget, parent_layout):
 class DialogManager:
     """A manager class for handling the creation of dialogs."""
 
+    MAX_TRANSITION_DELETION_PREVIEW_ITEMS = 200
+
     def __init__(self, parent):
         """
         Initialize the DialogManager.
@@ -281,12 +283,19 @@ class DialogManager:
                     (("apply", "Apply rotations"), ("discard", "Discard queue")),
                 )
         if deletion_entries:
-            trash_heading = QLabel(f"{len(deletion_entries)} item(s) will be removed")
+            is_truncated = bool(
+                deletion_entries and deletion_entries[-1][0] == ""
+            )
+            trash_heading = QLabel(
+                "Deletion targets"
+                if is_truncated
+                else f"{len(deletion_entries)} item(s) will be removed"
+            )
             trash_heading.setObjectName("workflowTransitionTrashTitle")
             body.addWidget(trash_heading)
             trash_description = QLabel(
-                "This includes marked files, folders, their contents, and empty folders "
-                "removed by Organize. Review the complete list before continuing."
+                "Folders include all descendants. The preview is intentionally "
+                "bounded so large directory trees do not stall the interface."
             )
             trash_description.setObjectName("workflowTransitionDescription")
             trash_description.setWordWrap(True)
@@ -551,9 +560,17 @@ class DialogManager:
     def _build_deletion_preview_entries(
         self, pending: WorkflowPendingState
     ) -> list[tuple[str, str, str, bool]]:
-        """Expand deletion targets into every affected file and folder."""
+        """Build a bounded target preview without walking marked directories."""
         entries: list[tuple[str, str, str, bool]] = []
         seen: set[str] = set()
+        directory_paths = {
+            os.path.normcase(os.path.normpath(path))
+            for path in pending.directory_paths
+            if path
+        }
+
+        def is_known_directory(path: str) -> bool:
+            return os.path.normcase(os.path.normpath(path)) in directory_paths
 
         def add(path: str, display_name: str, detail: str, is_directory: bool) -> None:
             normalized = os.path.normcase(os.path.normpath(path))
@@ -563,25 +580,14 @@ class DialogManager:
             entries.append((path, display_name, detail, is_directory))
 
         def add_target(path: str, detail: str, expand_directory: bool) -> None:
-            is_directory = os.path.isdir(path)
+            is_directory = is_known_directory(path)
             name = os.path.basename(os.path.normpath(path)) or path
+            if is_directory and expand_directory:
+                detail = f"{detail} (folder and all contents)"
             add(path, name, detail, is_directory)
-            if not is_directory or not expand_directory:
-                return
-            for current_root, dirnames, filenames in os.walk(path, followlinks=False):
-                dirnames.sort(key=str.casefold)
-                filenames.sort(key=str.casefold)
-                for dirname in dirnames:
-                    child = os.path.join(current_root, dirname)
-                    relative = os.path.relpath(child, path)
-                    add(child, relative, f"Folder inside {name}", True)
-                for filename in filenames:
-                    child = os.path.join(current_root, filename)
-                    relative = os.path.relpath(child, path)
-                    add(child, relative, f"Inside {name}", False)
 
         def canonical_targets(paths: list[str]) -> list[str]:
-            directories = [path for path in paths if os.path.isdir(path)]
+            directories = [path for path in paths if is_known_directory(path)]
             retained = []
             for path in paths:
                 covered = False
@@ -600,7 +606,7 @@ class DialogManager:
                     retained.append(path)
             return sorted(
                 dict.fromkeys(retained),
-                key=lambda path: (not os.path.isdir(path), path.casefold()),
+                key=lambda path: (not is_known_directory(path), path.casefold()),
             )
 
         for path in canonical_targets(pending.trash_paths):
@@ -613,7 +619,19 @@ class DialogManager:
                 "Empty folder removed after organizing",
                 expand_directory=False,
             )
-        return entries
+        maximum = self.MAX_TRANSITION_DELETION_PREVIEW_ITEMS
+        if len(entries) <= maximum:
+            return entries
+        omitted = len(entries) - maximum
+        return [
+            *entries[:maximum],
+            (
+                "",
+                f"… and {omitted} more target(s)",
+                "All targets remain included in the operation",
+                False,
+            ),
+        ]
 
     def _has_raw_images(self, file_paths: list[str]) -> bool:
         """Check if any of the provided file paths are RAW image files."""
@@ -2054,11 +2072,18 @@ class DialogManager:
         list_widget.setWordWrap(True)
         list_widget.setSpacing(10)
 
-        for file_path in files:
+        preview_files = files[: self.MAX_TRANSITION_DELETION_PREVIEW_ITEMS]
+        for file_path in preview_files:
             item = QListWidgetItem(
                 self._cached_thumbnail_icon(file_path),
                 os.path.basename(file_path),
             )
+            item.setSizeHint(QSize(148, 168))
+            item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
+            list_widget.addItem(item)
+        omitted = len(files) - len(preview_files)
+        if omitted > 0:
+            item = QListWidgetItem(f"… and {omitted} more item(s)")
             item.setSizeHint(QSize(148, 168))
             item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             list_widget.addItem(item)
@@ -2292,11 +2317,18 @@ class DialogManager:
         list_widget.setWordWrap(True)
         list_widget.setSpacing(10)
 
-        for file_path in marked_files:
+        preview_files = marked_files[: self.MAX_TRANSITION_DELETION_PREVIEW_ITEMS]
+        for file_path in preview_files:
             item = QListWidgetItem(
                 self._cached_thumbnail_icon(file_path),
                 os.path.basename(file_path),
             )
+            item.setSizeHint(QSize(148, 168))
+            item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
+            list_widget.addItem(item)
+        omitted = len(marked_files) - len(preview_files)
+        if omitted > 0:
+            item = QListWidgetItem(f"… and {omitted} more marked item(s)")
             item.setSizeHint(QSize(148, 168))
             item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             list_widget.addItem(item)

--- a/src/ui/grouping_step_widget.py
+++ b/src/ui/grouping_step_widget.py
@@ -1,18 +1,23 @@
+from __future__ import annotations
+
 import logging
 import copy
 import os
 import sys
 import time
-import subprocess
 from contextlib import suppress
 from collections.abc import Callable, Iterable
 from typing import override
 
 from PyQt6.QtCore import (
+    QAbstractListModel,
     QEvent,
+    QModelIndex,
     QObject,
     QItemSelectionModel,
+    QPointF,
     QPoint,
+    QProcess,
     QRunnable,
     QSize,
     Qt,
@@ -32,6 +37,10 @@ from PyQt6.QtGui import (
     QDropEvent,
     QIcon,
     QKeyEvent,
+    QPainter,
+    QPalette,
+    QPen,
+    QPolygonF,
 )
 from PyQt6.QtWidgets import (
     QAbstractItemView,
@@ -44,15 +53,15 @@ from PyQt6.QtWidgets import (
     QInputDialog,
     QLabel,
     QListView,
-    QListWidget,
-    QListWidgetItem,
     QMenu,
     QMessageBox,
     QProgressBar,
+    QProxyStyle,
     QPushButton,
     QSplitter,
     QStackedWidget,
     QStyle,
+    QStyleOption,
     QTreeWidget,
     QTreeWidgetItem,
     QVBoxLayout,
@@ -72,9 +81,12 @@ from core.app_settings import (
     get_companion_files_preference,
     set_companion_files_preference,
     DISPLAY_MAX_RESOLUTION,
+    LARGE_FOLDER_THRESHOLD,
     THUMBNAIL_PRELOAD_BATCH_SIZE,
     THUMBNAIL_PRELOAD_VISIBLE_MARGIN,
+    UI_POPULATION_CHUNK_SIZE,
 )
+from ui.helpers.ui_yield import cooperative_ui_yield
 from ui.advanced_image_viewer import SynchronizedImageViewer
 from ui.controllers.image_inspection_controller import InspectionImageSpec
 from ui.workflow_review_components import (
@@ -114,7 +126,6 @@ PREVIEW_PAGE_FOLDER = 2
 
 ROOT_LEVEL_GROUP_LABEL = "Root files"
 SELECTED_PREVIEW_DISPLAY_SIZE = DISPLAY_MAX_RESOLUTION
-MAX_FOLDER_PREVIEW_ITEMS = 200
 
 _DROP_TARGET_KINDS = {ITEM_GROUP, ITEM_DIRECTORY, ITEM_ROOT, ITEM_UNASSIGNED}
 _DRAGGABLE_KINDS = {ITEM_FILE, ITEM_GROUP}
@@ -435,6 +446,160 @@ class DroppableGroupingTree(QTreeWidget):
         return normalized_candidate.startswith(normalized_ancestor + os.sep)
 
 
+class GroupingTreeBranchStyle(QProxyStyle):
+    """Draw an unmistakable disclosure chevron for expandable tree rows."""
+
+    @override
+    def drawPrimitive(
+        self,
+        element: QStyle.PrimitiveElement,
+        option: QStyleOption,
+        painter: QPainter,
+        widget: QWidget | None = None,
+    ) -> None:
+        if element != QStyle.PrimitiveElement.PE_IndicatorBranch:
+            super().drawPrimitive(element, option, painter, widget)
+            return
+        if not option.state & QStyle.StateFlag.State_Children:
+            return
+
+        rect = option.rect
+        center_x = rect.center().x()
+        center_y = rect.center().y()
+        radius = max(3.0, min(4.5, min(rect.width(), rect.height()) / 3.0))
+        if option.state & QStyle.StateFlag.State_Open:
+            points = QPolygonF(
+                [
+                    QPointF(center_x - radius, center_y - radius / 2),
+                    QPointF(center_x, center_y + radius / 2),
+                    QPointF(center_x + radius, center_y - radius / 2),
+                ]
+            )
+        else:
+            points = QPolygonF(
+                [
+                    QPointF(center_x - radius / 2, center_y - radius),
+                    QPointF(center_x + radius / 2, center_y),
+                    QPointF(center_x - radius / 2, center_y + radius),
+                ]
+            )
+
+        color_role = (
+            QPalette.ColorRole.HighlightedText
+            if option.state & QStyle.StateFlag.State_Selected
+            else QPalette.ColorRole.Text
+        )
+        color = option.palette.color(color_role)
+        color.setAlpha(230)
+        pen = QPen(color, 1.8)
+        pen.setCapStyle(Qt.PenCapStyle.RoundCap)
+        pen.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
+
+        painter.save()
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        painter.setPen(pen)
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        painter.drawPolyline(points)
+        painter.restore()
+
+
+class FolderPreviewListModel(QAbstractListModel):
+    """Virtualized folder contents backed by the shared thumbnail cache."""
+
+    def __init__(self, owner: GroupingStepWidget):
+        super().__init__(owner)
+        self._owner = owner
+        self._paths: list[str] = []
+        self._row_by_path: dict[str, int] = {}
+
+    @override
+    def rowCount(self, parent: QModelIndex | None = None) -> int:
+        return 0 if parent is not None and parent.isValid() else len(self._paths)
+
+    @override
+    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole):
+        if not index.isValid() or not 0 <= index.row() < len(self._paths):
+            return None
+        source_path = self._paths[index.row()]
+        if role == Qt.ItemDataRole.DisplayRole:
+            return self._owner._preview_deletion_display_name(source_path)
+        if role == Qt.ItemDataRole.UserRole:
+            return source_path
+        if role == Qt.ItemDataRole.ToolTipRole:
+            return self._owner._relative_path_for_source(source_path)
+        if role == Qt.ItemDataRole.DecorationRole:
+            return (
+                self._owner._cached_thumbnail_icon_for_path(source_path)
+                or self._owner._file_icon
+            )
+        if (
+            role == Qt.ItemDataRole.ForegroundRole
+            and self._owner._is_marked_func(source_path)
+        ):
+            return QBrush(QColor("#FFB366"))
+        return None
+
+    def set_paths(self, paths: Iterable[str]) -> None:
+        unique_paths = list(dict.fromkeys(str(path) for path in paths if path))
+        self.beginResetModel()
+        self._paths = unique_paths
+        self._row_by_path = {
+            source_path: row for row, source_path in enumerate(unique_paths)
+        }
+        self.endResetModel()
+
+    def path_at(self, index: QModelIndex) -> str | None:
+        if not index.isValid() or not 0 <= index.row() < len(self._paths):
+            return None
+        return self._paths[index.row()]
+
+    def paths_slice(self, start: int, count: int) -> list[str]:
+        start = max(0, start)
+        return self._paths[start : start + max(0, count)]
+
+    def refresh_deletion_state(self) -> None:
+        if not self._paths:
+            return
+        self.dataChanged.emit(
+            self.index(0, 0),
+            self.index(len(self._paths) - 1, 0),
+            [
+                int(Qt.ItemDataRole.DisplayRole),
+                int(Qt.ItemDataRole.ForegroundRole),
+            ],
+        )
+
+    def refresh_thumbnail_paths(self, image_paths: set[str] | None = None) -> None:
+        if not self._paths:
+            return
+        if image_paths is None:
+            row_ranges = [(0, len(self._paths) - 1)]
+        else:
+            rows = sorted(
+                self._row_by_path[path]
+                for path in image_paths
+                if path in self._row_by_path
+            )
+            if not rows:
+                return
+            row_ranges: list[tuple[int, int]] = []
+            range_start = range_end = rows[0]
+            for row in rows[1:]:
+                if row == range_end + 1:
+                    range_end = row
+                    continue
+                row_ranges.append((range_start, range_end))
+                range_start = range_end = row
+            row_ranges.append((range_start, range_end))
+
+        for start, end in row_ranges:
+            self.dataChanged.emit(
+                self.index(start, 0),
+                self.index(end, 0),
+                [int(Qt.ItemDataRole.DecorationRole)],
+            )
+
+
 class GroupingStepWidget(QWidget):
     active_image_changed = pyqtSignal(str)
     mode_changed = pyqtSignal(str)
@@ -607,14 +772,26 @@ class GroupingStepWidget(QWidget):
         self.before_tree.setColumnCount(1)
         self.before_tree.setHeaderHidden(True)
         self.before_tree.setRootIsDecorated(True)
+        self.before_tree.setItemsExpandable(True)
         self.before_tree.setAlternatingRowColors(False)
-        self.before_tree.setIndentation(14)
+        self.before_tree.setIndentation(20)
         self.before_tree.setUniformRowHeights(True)
         self.before_tree.setSelectionMode(
             QAbstractItemView.SelectionMode.SingleSelection
         )
         self.before_tree.setIconSize(QSize(22, 22))
         self.before_tree.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self._before_tree_branch_style = GroupingTreeBranchStyle()
+        self._before_tree_branch_style.setParent(self.before_tree)
+        self.before_tree.setStyle(self._before_tree_branch_style)
+        self.before_expand_all_button = QPushButton("Expand all")
+        self.before_expand_all_button.setObjectName("groupingTreeControlButton")
+        self.before_expand_all_button.setToolTip("Expand all folders in Before")
+        self.before_expand_all_button.setEnabled(False)
+        self.before_collapse_all_button = QPushButton("Collapse all")
+        self.before_collapse_all_button.setObjectName("groupingTreeControlButton")
+        self.before_collapse_all_button.setToolTip("Collapse all folders in Before")
+        self.before_collapse_all_button.setEnabled(False)
 
         self.after_panel = QFrame()
         self.after_panel.setObjectName("groupingAfterPanel")
@@ -627,14 +804,39 @@ class GroupingStepWidget(QWidget):
         self.preview_tree.setColumnCount(1)
         self.preview_tree.setHeaderHidden(True)
         self.preview_tree.setRootIsDecorated(True)
+        self.preview_tree.setItemsExpandable(True)
         self.preview_tree.setAlternatingRowColors(False)
-        self.preview_tree.setIndentation(14)
+        self.preview_tree.setIndentation(20)
         self.preview_tree.setUniformRowHeights(True)
         self.preview_tree.setSelectionMode(
             QAbstractItemView.SelectionMode.ExtendedSelection
         )
         self.preview_tree.setIconSize(QSize(22, 22))
         self.preview_tree.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self._after_tree_branch_style = GroupingTreeBranchStyle()
+        self._after_tree_branch_style.setParent(self.preview_tree)
+        self.preview_tree.setStyle(self._after_tree_branch_style)
+        self.after_expand_all_button = QPushButton("Expand all")
+        self.after_expand_all_button.setObjectName("groupingTreeControlButton")
+        self.after_expand_all_button.setToolTip("Expand all folders in After")
+        self.after_expand_all_button.setEnabled(False)
+        self.after_collapse_all_button = QPushButton("Collapse all")
+        self.after_collapse_all_button.setObjectName("groupingTreeControlButton")
+        self.after_collapse_all_button.setToolTip("Collapse all folders in After")
+        self.after_collapse_all_button.setEnabled(False)
+
+        self._tree_expansion_timers: dict[QTreeWidget, QTimer] = {}
+        self._tree_expansion_stacks: dict[
+            QTreeWidget, list[QTreeWidgetItem]
+        ] = {}
+        self._tree_expansion_targets: dict[QTreeWidget, bool] = {}
+        for tree in (self.before_tree, self.preview_tree):
+            timer = QTimer(self)
+            timer.setInterval(0)
+            timer.timeout.connect(
+                lambda tree=tree: self._process_tree_expansion_batch(tree)
+            )
+            self._tree_expansion_timers[tree] = timer
 
         self.preview_panel = QFrame()
         self.preview_panel.setObjectName("groupingPreviewPanel")
@@ -664,19 +866,24 @@ class GroupingStepWidget(QWidget):
         self.folder_preview_meta = QLabel()
         self.folder_preview_meta.setObjectName("groupingPathValue")
         self.folder_preview_meta.setWordWrap(True)
-        self.folder_preview_grid = QListWidget()
+        self.folder_preview_grid = QListView()
         self.folder_preview_grid.setObjectName("groupingFolderPreviewGrid")
         self.folder_preview_grid.setViewMode(QListView.ViewMode.IconMode)
         self.folder_preview_grid.setResizeMode(QListView.ResizeMode.Adjust)
+        self.folder_preview_grid.setLayoutMode(QListView.LayoutMode.Batched)
+        self.folder_preview_grid.setBatchSize(UI_POPULATION_CHUNK_SIZE)
         self.folder_preview_grid.setMovement(QListView.Movement.Static)
         self.folder_preview_grid.setWrapping(True)
         self.folder_preview_grid.setSpacing(10)
         self.folder_preview_grid.setIconSize(QSize(120, 120))
+        self.folder_preview_grid.setGridSize(QSize(150, 165))
         self.folder_preview_grid.setSelectionMode(
             QAbstractItemView.SelectionMode.SingleSelection
         )
-        self.folder_preview_grid.setUniformItemSizes(False)
+        self.folder_preview_grid.setUniformItemSizes(True)
         self.folder_preview_grid.setWordWrap(True)
+        self._folder_preview_model = FolderPreviewListModel(self)
+        self.folder_preview_grid.setModel(self._folder_preview_model)
 
         self.stacked = QStackedWidget()
         self.main_splitter = QSplitter(Qt.Orientation.Horizontal)
@@ -765,6 +972,8 @@ class GroupingStepWidget(QWidget):
         bh.addWidget(self.before_header)
         bh.addWidget(self.before_desc)
         bh.addStretch(1)
+        bh.addWidget(self.before_expand_all_button)
+        bh.addWidget(self.before_collapse_all_button)
         bl.addLayout(bh)
         self._add_hsep(bl, "groupingPanelSep")
         bl.addWidget(self.before_tree, 1)
@@ -778,6 +987,8 @@ class GroupingStepWidget(QWidget):
         ah.addWidget(self.after_header)
         ah.addWidget(self.after_desc)
         ah.addStretch(1)
+        ah.addWidget(self.after_expand_all_button)
+        ah.addWidget(self.after_collapse_all_button)
         al.addLayout(ah)
         self._add_hsep(al, "groupingPanelSep")
         al.addWidget(self.preview_tree, 1)
@@ -868,13 +1079,28 @@ class GroupingStepWidget(QWidget):
         self.preview_tree.customContextMenuRequested.connect(
             self._show_after_context_menu
         )
-        self.folder_preview_grid.itemActivated.connect(
+        self.folder_preview_grid.activated.connect(
             self._handle_folder_preview_item_activated
         )
-        self.folder_preview_grid.itemClicked.connect(
+        self.folder_preview_grid.clicked.connect(
             self._handle_folder_preview_item_activated
+        )
+        self.folder_preview_grid.verticalScrollBar().valueChanged.connect(
+            self._schedule_folder_preview_thumbnails
         )
         self.preview_trash_button.clicked.connect(self._trash_current_preview)
+        self.before_expand_all_button.clicked.connect(
+            lambda: self._set_all_tree_folders_expanded(self.before_tree, True)
+        )
+        self.before_collapse_all_button.clicked.connect(
+            lambda: self._set_all_tree_folders_expanded(self.before_tree, False)
+        )
+        self.after_expand_all_button.clicked.connect(
+            lambda: self._set_all_tree_folders_expanded(self.preview_tree, True)
+        )
+        self.after_collapse_all_button.clicked.connect(
+            lambda: self._set_all_tree_folders_expanded(self.preview_tree, False)
+        )
         self._location_depth_group.buttonClicked.connect(
             self._on_location_depth_changed
         )
@@ -1075,21 +1301,7 @@ class GroupingStepWidget(QWidget):
             self._apply_deletion_presentation(item, path, editable=False)
         for path, item in self._after_file_items_by_path.items():
             self._apply_deletion_presentation(item, path, editable=True)
-        for index in range(self.folder_preview_grid.count()):
-            item = self.folder_preview_grid.item(index)
-            if item is None:
-                continue
-            path = item.data(Qt.ItemDataRole.UserRole)
-            if path:
-                path = str(path)
-                item.setText(self._preview_deletion_display_name(path))
-                item.setForeground(
-                    QBrush(
-                        QColor("#FFB366")
-                        if self._is_marked_func(path)
-                        else QApplication.palette().text().color()
-                    )
-                )
+        self._folder_preview_model.refresh_deletion_state()
         current = self._current_preview_source_path
         if current:
             display_name = self._preview_deletion_display_name(current)
@@ -1159,9 +1371,12 @@ class GroupingStepWidget(QWidget):
         for btn in self._mode_buttons.values():
             btn.setEnabled(has_folder)
         if not has_folder:
+            self._cancel_all_tree_expansion_operations()
             self._current_preview_source_path = None
             self.before_tree.clear()
             self.preview_tree.clear()
+            self._update_tree_control_buttons(self.before_tree)
+            self._update_tree_control_buttons(self.preview_tree)
             self._current_plan = None
             self._current_output_root = ""
             self._editable_groups = []
@@ -1264,7 +1479,24 @@ class GroupingStepWidget(QWidget):
             deleted_paths=[],
             filesystem_inventory_complete=True,
             source_root=self._source_root or "",
+            filesystem_paths=set(
+                getattr(self._current_plan, "filesystem_paths", set())
+                if self._current_plan is not None
+                else set()
+            ),
+            filesystem_directories=set(
+                getattr(self._current_plan, "filesystem_directories", set())
+                if self._current_plan is not None
+                else set()
+            ),
         )
+
+    def known_directory_paths(self) -> set[str]:
+        """Return the worker-inventoried directories without touching the filesystem."""
+
+        if self._current_plan is None:
+            return set()
+        return set(getattr(self._current_plan, "filesystem_directories", set()))
 
     def has_unsaved_grouping_edits(self) -> bool:
         if self._current_plan is None:
@@ -1363,11 +1595,15 @@ class GroupingStepWidget(QWidget):
 
     def _refresh_preview_trees(self, preserve_selection: bool = True) -> None:
         start_time = time.perf_counter()
+        self._cancel_all_tree_expansion_operations()
+        source_path_count = len(self._all_source_paths())
+        self._tree_population_processed = 0
+        self._tree_population_total = source_path_count * 2
         logger.info(
             "Organize tree refresh start: preserve_selection=%s editable_groups=%d all_source_paths=%d",
             preserve_selection,
             len(self._editable_groups),
-            len(self._all_source_paths()),
+            source_path_count,
         )
         selection_state = (
             self._capture_selection_state() if preserve_selection else None
@@ -1387,6 +1623,8 @@ class GroupingStepWidget(QWidget):
             self.preview_tree.setUpdatesEnabled(True)
             self.before_tree.viewport().update()
             self.preview_tree.viewport().update()
+            self._tree_population_processed = 0
+            self._tree_population_total = 0
         logger.info(
             "Organize tree refresh complete in %.3fs (before=%.3fs after=%.3fs)",
             time.perf_counter() - start_time,
@@ -1689,6 +1927,7 @@ class GroupingStepWidget(QWidget):
                 group_item.addChild(file_item)
                 self._after_file_items_by_path[source_path] = file_item
                 self._apply_deletion_presentation(file_item, source_path, editable=True)
+                self._note_tree_item_populated()
 
         self._add_bucket_item(
             root_item,
@@ -1707,7 +1946,11 @@ class GroupingStepWidget(QWidget):
             self._source_root or self._current_output_root,
         )
 
-        self.preview_tree.expandAll()
+        if len(self._after_file_items_by_path) > LARGE_FOLDER_THRESHOLD:
+            root_item.setExpanded(True)
+        else:
+            self.preview_tree.expandAll()
+        self._update_tree_control_buttons(self.preview_tree)
         self._ignore_preview_item_change = False
         self._restore_selection_state(selection_state)
         logger.info(
@@ -1769,6 +2012,20 @@ class GroupingStepWidget(QWidget):
             bucket_item.addChild(file_item)
             self._after_file_items_by_path[source_path] = file_item
             self._apply_deletion_presentation(file_item, source_path, editable=True)
+            self._note_tree_item_populated()
+
+    def _note_tree_item_populated(self) -> None:
+        self._tree_population_processed = (
+            getattr(self, "_tree_population_processed", 0) + 1
+        )
+        total = getattr(self, "_tree_population_total", 0)
+        cooperative_ui_yield(
+            self._tree_population_processed,
+            total,
+            progress_callback=lambda processed, count: self.loading_label.setText(
+                f"Building folder preview: {processed}/{count}..."
+            ),
+        )
 
     def _render_before_tree(self) -> None:
         start_time = time.perf_counter()
@@ -1864,8 +2121,13 @@ class GroupingStepWidget(QWidget):
             parent_item.addChild(file_item)
             self._before_file_items_by_path[source_path] = file_item
             self._apply_deletion_presentation(file_item, source_path, editable=False)
+            self._note_tree_item_populated()
 
-        self.before_tree.expandAll()
+        if len(self._before_file_items_by_path) > LARGE_FOLDER_THRESHOLD:
+            root_item.setExpanded(True)
+        else:
+            self.before_tree.expandAll()
+        self._update_tree_control_buttons(self.before_tree)
         logger.info(
             "Organize before tree built in %.3fs (files=%d dirs=%d)",
             time.perf_counter() - start_time,
@@ -2148,28 +2410,30 @@ class GroupingStepWidget(QWidget):
             if self.preview_pane_stack.currentIndex() != PREVIEW_PAGE_FOLDER:
                 return []
             grid = self.folder_preview_grid
-            viewport_rect = grid.viewport().rect()
-            margin = max(0, viewport_rect.height())
-            preload_rect = viewport_rect.adjusted(0, -margin, 0, margin)
-            visible_paths: list[str] = []
-            fallback_paths: list[str] = []
-            for index in range(grid.count()):
-                item = grid.item(index)
-                if item is None:
-                    continue
-                source_path = item.data(Qt.ItemDataRole.UserRole)
-                if not source_path:
-                    continue
-                source_path = str(source_path)
-                if len(fallback_paths) < limit:
-                    fallback_paths.append(source_path)
-                if grid.visualItemRect(item).intersects(preload_rect):
-                    visible_paths.append(source_path)
-                    if len(visible_paths) >= limit:
-                        break
-            # A newly populated/offscreen widget may not have valid visual rects
-            # until the next layout pass; its first page is still the right work.
-            return visible_paths or fallback_paths
+            row_count = self._folder_preview_model.rowCount()
+            if row_count <= 0:
+                return []
+
+            viewport = grid.viewport().rect()
+            sample_points = (
+                QPoint(grid.spacing() + 1, grid.spacing() + 1),
+                QPoint(max(1, viewport.center().x()), grid.spacing() + 1),
+                QPoint(grid.spacing() + 1, max(1, viewport.center().y())),
+            )
+            visible_rows = [
+                index.row()
+                for point in sample_points
+                if (index := grid.indexAt(point)).isValid()
+            ]
+            if visible_rows:
+                first_row = min(visible_rows)
+            else:
+                scroll_bar = grid.verticalScrollBar()
+                maximum = scroll_bar.maximum()
+                ratio = scroll_bar.value() / maximum if maximum > 0 else 0.0
+                first_row = int(ratio * max(0, row_count - 1))
+            start_row = max(0, first_row - THUMBNAIL_PRELOAD_VISIBLE_MARGIN)
+            return self._folder_preview_model.paths_slice(start_row, limit)
 
         combined = (
             paths_for_folder_preview()
@@ -2259,7 +2523,7 @@ class GroupingStepWidget(QWidget):
         self.large_preview_name.clear()
         self.folder_preview_title.clear()
         self.folder_preview_meta.clear()
-        self.folder_preview_grid.clear()
+        self._folder_preview_model.set_paths([])
         self.preview_pane_stack.setCurrentIndex(PREVIEW_PAGE_HINT)
         self.preview_trash_button.setEnabled(False)
         self.large_preview_name.setStyleSheet("")
@@ -2380,29 +2644,11 @@ class GroupingStepWidget(QWidget):
             return
 
         total_preview_paths = len(preview_paths)
-        visible_preview_paths = preview_paths[:MAX_FOLDER_PREVIEW_ITEMS]
-        self.folder_preview_grid.clear()
-        for source_path in visible_preview_paths:
-            list_item = QListWidgetItem(
-                self._preview_deletion_display_name(source_path)
-            )
-            list_item.setData(Qt.ItemDataRole.UserRole, source_path)
-            list_item.setToolTip(self._relative_path_for_source(source_path))
-            if self._is_marked_func(source_path):
-                list_item.setForeground(QBrush(QColor("#FFB366")))
-            icon = self._cached_thumbnail_icon_for_path(source_path)
-            if icon is not None:
-                list_item.setIcon(icon)
-            else:
-                list_item.setIcon(self._file_icon)
-            self.folder_preview_grid.addItem(list_item)
+        self._folder_preview_model.set_paths(preview_paths)
 
         item_label = self._display_label_for_item(item)
         self.folder_preview_title.setText(item_label)
-        if total_preview_paths > MAX_FOLDER_PREVIEW_ITEMS:
-            meta_count = f"{total_preview_paths} item(s) · showing first {MAX_FOLDER_PREVIEW_ITEMS}"
-        else:
-            meta_count = f"{total_preview_paths} item(s)"
+        meta_count = f"{total_preview_paths} item(s)"
         self.folder_preview_meta.setText(
             f"{meta_count}\n{self._display_path_for_item(item)}"
         )
@@ -2412,20 +2658,12 @@ class GroupingStepWidget(QWidget):
         self.preview_selection_label.setVisible(True)
         self.preview_selection_meta.setText(meta_count)
         self.preview_selection_meta.setVisible(True)
-        if self._parent_window is not None:
-            schedule_thumbnails = getattr(
-                self._parent_window,
-                "schedule_visible_thumbnail_load",
-                None,
-            )
-            if callable(schedule_thumbnails):
-                schedule_thumbnails()
+        self._schedule_folder_preview_thumbnails()
         logger.debug(
-            "Organize folder preview updated in %.3fs (item=%s total_paths=%d visible_paths=%d)",
+            "Organize folder preview updated in %.3fs (item=%s total_paths=%d)",
             time.perf_counter() - start_time,
             item_label,
             total_preview_paths,
-            len(visible_preview_paths),
         )
 
     def _folder_preview_paths_for_item(self, item: QTreeWidgetItem | None) -> list[str]:
@@ -2455,12 +2693,17 @@ class GroupingStepWidget(QWidget):
     def _collect_descendant_source_paths(
         self, item: QTreeWidgetItem, collected_paths: list[str]
     ) -> None:
-        source_path = self._item_source_path(item)
-        if source_path:
-            collected_paths.append(source_path)
-            return
-        for index in range(item.childCount()):
-            self._collect_descendant_source_paths(item.child(index), collected_paths)
+        stack = [item]
+        while stack:
+            current = stack.pop()
+            source_path = self._item_source_path(current)
+            if source_path:
+                collected_paths.append(source_path)
+                continue
+            stack.extend(
+                current.child(index)
+                for index in range(current.childCount() - 1, -1, -1)
+            )
 
     def _cached_thumbnail_icon_for_path(self, source_path: str) -> QIcon | None:
         if self._parent_window is not None:
@@ -2551,18 +2794,16 @@ class GroupingStepWidget(QWidget):
     def _refresh_folder_preview_icons_from_cache(
         self, image_paths: set[str] | None = None
     ) -> None:
-        for index in range(self.folder_preview_grid.count()):
-            item = self.folder_preview_grid.item(index)
-            if item is None:
-                continue
-            source_path = item.data(Qt.ItemDataRole.UserRole)
-            if not source_path:
-                continue
-            if image_paths is not None and str(source_path) not in image_paths:
-                continue
-            icon = self._cached_thumbnail_icon_for_path(str(source_path))
-            if icon is not None:
-                item.setIcon(icon)
+        self._folder_preview_model.refresh_thumbnail_paths(image_paths)
+
+    def _schedule_folder_preview_thumbnails(self, *_args) -> None:
+        schedule_thumbnails = getattr(
+            self._parent_window,
+            "schedule_visible_thumbnail_load",
+            None,
+        )
+        if callable(schedule_thumbnails):
+            schedule_thumbnails()
 
     def _display_label_for_item(self, item: QTreeWidgetItem) -> str:
         text = item.text(0).strip()
@@ -2583,14 +2824,10 @@ class GroupingStepWidget(QWidget):
             return relative_path
         return self._source_root or ""
 
-    def _handle_folder_preview_item_activated(
-        self, item: QListWidgetItem | None
-    ) -> None:
-        if item is None:
-            return
-        source_path = item.data(Qt.ItemDataRole.UserRole)
+    def _handle_folder_preview_item_activated(self, index: QModelIndex) -> None:
+        source_path = self._folder_preview_model.path_at(index)
         if source_path:
-            self._focus_path_in_trees(str(source_path))
+            self._focus_path_in_trees(source_path)
 
     def _focus_path_in_trees(self, source_path: str) -> None:
         after_item = self._after_file_items_by_path.get(source_path)
@@ -2981,20 +3218,20 @@ class GroupingStepWidget(QWidget):
         normalized = os.path.normpath(path)
         try:
             if os.name == "nt":
-                subprocess.run(["explorer", "/select,", normalized], check=False)
+                QProcess.startDetached("explorer", ["/select,", normalized])
             elif os.name == "posix":
                 if os.uname().sysname == "Darwin":
                     if os.path.isdir(normalized):
-                        subprocess.run(["open", normalized], check=False)
+                        QProcess.startDetached("open", [normalized])
                     else:
-                        subprocess.run(["open", "-R", normalized], check=False)
+                        QProcess.startDetached("open", ["-R", normalized])
                 else:
                     target = (
                         normalized
                         if os.path.isdir(normalized)
                         else os.path.dirname(normalized)
                     )
-                    subprocess.run(["xdg-open", target], check=False)
+                    QProcess.startDetached("xdg-open", [target])
         except Exception:
             self._show_status_message(f"Failed to reveal {path}.", 3000)
 
@@ -3004,13 +3241,13 @@ class GroupingStepWidget(QWidget):
         target = path if os.path.isdir(path) else os.path.dirname(path)
         try:
             if os.name == "posix" and os.uname().sysname == "Darwin":
-                subprocess.run(["open", "-a", "Terminal", target], check=False)
+                QProcess.startDetached("open", ["-a", "Terminal", target])
             elif os.name == "posix":
-                subprocess.run(["xdg-open", target], check=False)
+                QProcess.startDetached("xdg-open", [target])
             elif os.name == "nt":
-                subprocess.run(
-                    ["cmd", "/c", "start", "cmd.exe", "/K", f"cd /d {target}"],
-                    check=False,
+                QProcess.startDetached(
+                    "cmd",
+                    ["/c", "start", "cmd.exe", "/K", f"cd /d {target}"],
                 )
         except Exception:
             self._show_status_message(f"Failed to open terminal for {target}.", 3000)
@@ -3020,6 +3257,95 @@ class GroupingStepWidget(QWidget):
             self._parent_window.statusBar().showMessage(message, timeout)
 
     _AFTER_DESC_DEFAULT = "Drag items to move \u00b7 Double-click to rename"
+
+    def _tree_control_buttons(
+        self, tree: QTreeWidget
+    ) -> tuple[QPushButton, QPushButton]:
+        if tree is self.before_tree:
+            return self.before_expand_all_button, self.before_collapse_all_button
+        return self.after_expand_all_button, self.after_collapse_all_button
+
+    def _update_tree_control_buttons(self, tree: QTreeWidget) -> None:
+        enabled = tree.topLevelItemCount() > 0
+        for button in self._tree_control_buttons(tree):
+            button.setEnabled(enabled)
+
+    def _cancel_tree_expansion_operation(self, tree: QTreeWidget) -> None:
+        timer = self._tree_expansion_timers.get(tree)
+        if timer is not None:
+            timer.stop()
+        self._tree_expansion_stacks.pop(tree, None)
+        self._tree_expansion_targets.pop(tree, None)
+
+    def _cancel_all_tree_expansion_operations(self) -> None:
+        for tree in (self.before_tree, self.preview_tree):
+            self._cancel_tree_expansion_operation(tree)
+
+    def _tree_file_count(self, tree: QTreeWidget) -> int:
+        if tree is self.before_tree:
+            return len(self._before_file_items_by_path)
+        return len(self._after_file_items_by_path)
+
+    def _set_all_tree_folders_expanded(
+        self, tree: QTreeWidget, expanded: bool
+    ) -> None:
+        """Expand or collapse one complete tree without freezing large folders."""
+
+        self._cancel_tree_expansion_operation(tree)
+        if tree.topLevelItemCount() <= 0:
+            self._update_tree_control_buttons(tree)
+            return
+
+        if self._tree_file_count(tree) <= LARGE_FOLDER_THRESHOLD:
+            tree.setUpdatesEnabled(False)
+            try:
+                if expanded:
+                    tree.expandAll()
+                else:
+                    tree.collapseAll()
+            finally:
+                tree.setUpdatesEnabled(True)
+                tree.viewport().update()
+            return
+
+        self._tree_expansion_stacks[tree] = [
+            tree.topLevelItem(index)
+            for index in range(tree.topLevelItemCount() - 1, -1, -1)
+            if tree.topLevelItem(index) is not None
+        ]
+        self._tree_expansion_targets[tree] = expanded
+        self._tree_expansion_timers[tree].start()
+        self._process_tree_expansion_batch(tree)
+
+    def _process_tree_expansion_batch(self, tree: QTreeWidget) -> None:
+        stack = self._tree_expansion_stacks.get(tree)
+        if stack is None:
+            self._cancel_tree_expansion_operation(tree)
+            return
+
+        expanded = self._tree_expansion_targets.get(tree, False)
+        processed = 0
+        tree.setUpdatesEnabled(False)
+        try:
+            while stack and processed < UI_POPULATION_CHUNK_SIZE:
+                item = stack.pop()
+                children = [
+                    item.child(index) for index in range(item.childCount())
+                ]
+                stack.extend(reversed(children))
+                if children:
+                    item.setExpanded(expanded)
+                processed += 1
+        except RuntimeError:
+            # A refresh can invalidate QTreeWidgetItem wrappers between timer ticks.
+            self._cancel_tree_expansion_operation(tree)
+            return
+        finally:
+            tree.setUpdatesEnabled(True)
+            tree.viewport().update()
+
+        if not stack:
+            self._cancel_tree_expansion_operation(tree)
 
     def _set_subtree_expanded(
         self, tree: QTreeWidget, item: QTreeWidgetItem, expanded: bool
@@ -3437,7 +3763,7 @@ class GroupingStepWidget(QWidget):
     def _toggle_item_deletion_marks(self, item: QTreeWidgetItem) -> None:
         selected_paths = self._selected_preview_file_paths()
         paths = selected_paths or self._preview_paths_for_item(item)
-        paths = [path for path in dict.fromkeys(paths) if os.path.isfile(path)]
+        paths = list(dict.fromkeys(path for path in paths if path))
         if not paths:
             self._show_status_message("No files are available to mark.", 3000)
             return
@@ -3455,9 +3781,9 @@ class GroupingStepWidget(QWidget):
     def _request_trash_for_item(self, item: QTreeWidgetItem) -> None:
         selected_paths = self._selected_preview_file_paths()
         if selected_paths:
-            existing = [path for path in selected_paths if os.path.isfile(path)]
-            if existing:
-                self.trash_requested.emit("", existing)
+            paths = list(dict.fromkeys(path for path in selected_paths if path))
+            if paths:
+                self.trash_requested.emit("", paths)
             return
 
         target_path = self._deletable_path_for_item(item)
@@ -3657,8 +3983,15 @@ class GroupingStepWidget(QWidget):
                 f"{os.path.relpath(destination_path, self._current_output_root or self._source_root or os.path.dirname(destination_path))}"
             )
         deleted_file_paths: list[str] = []
+        known_directories = {
+            os.path.normcase(os.path.normpath(path))
+            for path in getattr(plan, "filesystem_directories", set())
+        }
         for deleted_path in getattr(plan, "deleted_paths", []) or []:
-            if os.path.isdir(deleted_path):
+            if (
+                os.path.normcase(os.path.normpath(deleted_path))
+                in known_directories
+            ):
                 lines.append(
                     f"Delete folder {self._relative_display_path(deleted_path)}"
                 )
@@ -3674,18 +4007,18 @@ class GroupingStepWidget(QWidget):
         return lines
 
     def _occupied_paths_for_action_preview(self) -> set[str]:
-        root = self._current_output_root or self._source_root or ""
-        if not root or not os.path.isdir(root):
-            return set()
-        occupied: set[str] = set()
-        for current_root, _dirnames, filenames in os.walk(root):
-            for filename in filenames:
-                occupied.add(
-                    os.path.normcase(
-                        os.path.normpath(os.path.join(current_root, filename))
-                    )
-                )
-        return occupied
+        """Use the worker-prepared inventory; never walk the tree from the UI."""
+
+        prepared_paths = (
+            getattr(self._current_plan, "filesystem_paths", set())
+            if self._current_plan is not None
+            else set()
+        )
+        paths = set(prepared_paths)
+        paths.update(self._all_source_paths())
+        return {
+            os.path.normcase(os.path.normpath(path)) for path in paths if path
+        }
 
     def _preview_destination_path(
         self,
@@ -3714,39 +4047,100 @@ class GroupingStepWidget(QWidget):
 
     def _empty_directories_after_move(self, moving_paths: Iterable[str]) -> list[str]:
         source_root = self._source_root or ""
-        if not source_root or not os.path.isdir(source_root):
+        if not source_root:
             return []
         normalized_source_root = os.path.normcase(os.path.normpath(source_root))
-        moving_set: set[str] = set()
+        prepared_paths = (
+            set(getattr(self._current_plan, "filesystem_paths", set()))
+            if self._current_plan is not None
+            else set()
+        )
+        inventory_is_complete = bool(
+            self._current_plan is not None
+            and getattr(
+                self._current_plan, "filesystem_inventory_complete", False
+            )
+        )
+        if not prepared_paths and not inventory_is_complete:
+            prepared_paths = set(self._all_source_paths())
+        known_paths = {
+            os.path.normcase(os.path.normpath(path))
+            for path in prepared_paths
+            if path
+        }
+        moving_set = {
+            os.path.normcase(os.path.normpath(path))
+            for path in moving_paths
+            if path
+            and (
+                not inventory_is_complete
+                or os.path.normcase(os.path.normpath(path)) in known_paths
+            )
+        }
+        if not moving_set:
+            return []
         candidate_dirs: dict[str, str] = {}
         for path in moving_paths:
-            if path and os.path.exists(path):
-                normalized_path = os.path.normcase(os.path.normpath(path))
-                moving_set.add(normalized_path)
-                current_dir = os.path.dirname(os.path.normpath(path))
-                while current_dir:
-                    normalized_dir = os.path.normcase(os.path.normpath(current_dir))
-                    if normalized_dir == normalized_source_root:
-                        break
-                    try:
-                        common_root = os.path.normcase(
+            if (
+                not path
+                or os.path.normcase(os.path.normpath(path)) not in moving_set
+            ):
+                continue
+            current_dir = os.path.dirname(os.path.normpath(path))
+            while current_dir:
+                normalized_dir = os.path.normcase(os.path.normpath(current_dir))
+                if normalized_dir == normalized_source_root:
+                    break
+                try:
+                    within_source = (
+                        os.path.normcase(
                             os.path.normpath(
                                 os.path.commonpath([source_root, current_dir])
                             )
                         )
-                        within_source = common_root == normalized_source_root
-                    except ValueError:
-                        within_source = False
-                    if not within_source:
-                        break
-                    candidate_dirs[normalized_dir] = current_dir
-                    parent_dir = os.path.dirname(current_dir)
-                    if parent_dir == current_dir:
-                        break
-                    current_dir = parent_dir
+                        == normalized_source_root
+                    )
+                except ValueError:
+                    within_source = False
+                if not within_source:
+                    break
+                candidate_dirs[normalized_dir] = current_dir
+                parent_dir = os.path.dirname(current_dir)
+                if parent_dir == current_dir:
+                    break
+                current_dir = parent_dir
 
         if not candidate_dirs:
             return []
+
+        remaining_files_by_dir: dict[str, int] = {}
+        for path in prepared_paths:
+            normalized_path = os.path.normcase(os.path.normpath(path))
+            if normalized_path in moving_set:
+                continue
+            parent_key = os.path.normcase(
+                os.path.normpath(os.path.dirname(path))
+            )
+            remaining_files_by_dir[parent_key] = (
+                remaining_files_by_dir.get(parent_key, 0) + 1
+            )
+
+        prepared_directories = (
+            set(getattr(self._current_plan, "filesystem_directories", set()))
+            if self._current_plan is not None
+            else set()
+        )
+        if not prepared_directories:
+            prepared_directories = {
+                os.path.dirname(path) for path in prepared_paths if path
+            }
+        child_dirs_by_parent: dict[str, set[str]] = {}
+        for directory in prepared_directories:
+            directory_key = os.path.normcase(os.path.normpath(directory))
+            parent_key = os.path.normcase(
+                os.path.normpath(os.path.dirname(directory))
+            )
+            child_dirs_by_parent.setdefault(parent_key, set()).add(directory_key)
 
         removable_dirs: set[str] = set()
         removable_dirs_by_key: dict[str, str] = {}
@@ -3756,19 +4150,10 @@ class GroupingStepWidget(QWidget):
             reverse=True,
         )
         for normalized_current, current_root in ordered_candidates:
-            try:
-                entries = list(os.scandir(current_root))
-            except OSError:
-                continue
-            remaining_files = any(
-                os.path.normcase(os.path.normpath(entry.path)) not in moving_set
-                for entry in entries
-                if not entry.is_dir(follow_symlinks=False)
-            )
+            remaining_files = bool(remaining_files_by_dir.get(normalized_current))
             remaining_children = any(
-                os.path.normcase(os.path.normpath(entry.path)) not in removable_dirs
-                for entry in entries
-                if entry.is_dir(follow_symlinks=False)
+                child not in removable_dirs
+                for child in child_dirs_by_parent.get(normalized_current, set())
             )
             if not remaining_files and not remaining_children:
                 removable_dirs.add(normalized_current)
@@ -3789,6 +4174,33 @@ class GroupingStepWidget(QWidget):
             pass
         return path
 
+    def _navigate_tree_left(self, tree: QTreeWidget) -> bool:
+        """Apply file-browser Left behavior: parent first, then collapse."""
+
+        current_item = tree.currentItem()
+        if current_item is None:
+            return False
+        if current_item.childCount() > 0 and current_item.isExpanded():
+            current_item.setExpanded(False)
+            return True
+
+        parent_item = current_item.parent()
+        if parent_item is not None:
+            tree.setCurrentItem(
+                parent_item,
+                0,
+                QItemSelectionModel.SelectionFlag.ClearAndSelect
+                | QItemSelectionModel.SelectionFlag.Rows,
+            )
+            tree.scrollToItem(
+                parent_item,
+                QAbstractItemView.ScrollHint.EnsureVisible,
+            )
+            return True
+
+        # Keep the current root selected instead of allowing focus to drift.
+        return True
+
     @override
     def eventFilter(self, obj: QObject, event: QEvent) -> bool:
         if event.type() == QEvent.Type.KeyPress:
@@ -3796,6 +4208,17 @@ class GroupingStepWidget(QWidget):
                 key_event: QKeyEvent = event
                 key = key_event.key()
                 modifiers = key_event.modifiers()
+                tree: QTreeWidget = obj
+                is_unmodified = modifiers in (
+                    Qt.KeyboardModifier.NoModifier,
+                    Qt.KeyboardModifier.KeypadModifier,
+                )
+                if (
+                    key == Qt.Key.Key_Left
+                    and is_unmodified
+                    and tree.state() != QAbstractItemView.State.EditingState
+                ):
+                    return self._navigate_tree_left(tree)
                 is_up = key in (Qt.Key.Key_Up, Qt.Key.Key_K)
                 is_down = key in (Qt.Key.Key_Down, Qt.Key.Key_J)
                 if is_up or is_down:
@@ -3808,7 +4231,6 @@ class GroupingStepWidget(QWidget):
                             else bool(modifiers & Qt.KeyboardModifier.ControlModifier)
                         )
                         skip_deleted = not has_special
-                        tree: QTreeWidget = obj
                         current_item = tree.currentItem()
                         if current_item is not None:
                             candidate = current_item

--- a/src/ui/grouping_step_widget.py
+++ b/src/ui/grouping_step_widget.py
@@ -532,9 +532,8 @@ class FolderPreviewListModel(QAbstractListModel):
                 self._owner._cached_thumbnail_icon_for_path(source_path)
                 or self._owner._file_icon
             )
-        if (
-            role == Qt.ItemDataRole.ForegroundRole
-            and self._owner._is_marked_func(source_path)
+        if role == Qt.ItemDataRole.ForegroundRole and self._owner._is_marked_func(
+            source_path
         ):
             return QBrush(QColor("#FFB366"))
         return None
@@ -826,9 +825,7 @@ class GroupingStepWidget(QWidget):
         self.after_collapse_all_button.setEnabled(False)
 
         self._tree_expansion_timers: dict[QTreeWidget, QTimer] = {}
-        self._tree_expansion_stacks: dict[
-            QTreeWidget, list[QTreeWidgetItem]
-        ] = {}
+        self._tree_expansion_stacks: dict[QTreeWidget, list[QTreeWidgetItem]] = {}
         self._tree_expansion_targets: dict[QTreeWidget, bool] = {}
         for tree in (self.before_tree, self.preview_tree):
             timer = QTimer(self)
@@ -3286,9 +3283,7 @@ class GroupingStepWidget(QWidget):
             return len(self._before_file_items_by_path)
         return len(self._after_file_items_by_path)
 
-    def _set_all_tree_folders_expanded(
-        self, tree: QTreeWidget, expanded: bool
-    ) -> None:
+    def _set_all_tree_folders_expanded(self, tree: QTreeWidget, expanded: bool) -> None:
         """Expand or collapse one complete tree without freezing large folders."""
 
         self._cancel_tree_expansion_operation(tree)
@@ -3329,9 +3324,7 @@ class GroupingStepWidget(QWidget):
         try:
             while stack and processed < UI_POPULATION_CHUNK_SIZE:
                 item = stack.pop()
-                children = [
-                    item.child(index) for index in range(item.childCount())
-                ]
+                children = [item.child(index) for index in range(item.childCount())]
                 stack.extend(reversed(children))
                 if children:
                     item.setExpanded(expanded)
@@ -3988,10 +3981,7 @@ class GroupingStepWidget(QWidget):
             for path in getattr(plan, "filesystem_directories", set())
         }
         for deleted_path in getattr(plan, "deleted_paths", []) or []:
-            if (
-                os.path.normcase(os.path.normpath(deleted_path))
-                in known_directories
-            ):
+            if os.path.normcase(os.path.normpath(deleted_path)) in known_directories:
                 lines.append(
                     f"Delete folder {self._relative_display_path(deleted_path)}"
                 )
@@ -4016,9 +4006,7 @@ class GroupingStepWidget(QWidget):
         )
         paths = set(prepared_paths)
         paths.update(self._all_source_paths())
-        return {
-            os.path.normcase(os.path.normpath(path)) for path in paths if path
-        }
+        return {os.path.normcase(os.path.normpath(path)) for path in paths if path}
 
     def _preview_destination_path(
         self,
@@ -4057,16 +4045,12 @@ class GroupingStepWidget(QWidget):
         )
         inventory_is_complete = bool(
             self._current_plan is not None
-            and getattr(
-                self._current_plan, "filesystem_inventory_complete", False
-            )
+            and getattr(self._current_plan, "filesystem_inventory_complete", False)
         )
         if not prepared_paths and not inventory_is_complete:
             prepared_paths = set(self._all_source_paths())
         known_paths = {
-            os.path.normcase(os.path.normpath(path))
-            for path in prepared_paths
-            if path
+            os.path.normcase(os.path.normpath(path)) for path in prepared_paths if path
         }
         moving_set = {
             os.path.normcase(os.path.normpath(path))
@@ -4081,10 +4065,7 @@ class GroupingStepWidget(QWidget):
             return []
         candidate_dirs: dict[str, str] = {}
         for path in moving_paths:
-            if (
-                not path
-                or os.path.normcase(os.path.normpath(path)) not in moving_set
-            ):
+            if not path or os.path.normcase(os.path.normpath(path)) not in moving_set:
                 continue
             current_dir = os.path.dirname(os.path.normpath(path))
             while current_dir:
@@ -4118,9 +4099,7 @@ class GroupingStepWidget(QWidget):
             normalized_path = os.path.normcase(os.path.normpath(path))
             if normalized_path in moving_set:
                 continue
-            parent_key = os.path.normcase(
-                os.path.normpath(os.path.dirname(path))
-            )
+            parent_key = os.path.normcase(os.path.normpath(os.path.dirname(path)))
             remaining_files_by_dir[parent_key] = (
                 remaining_files_by_dir.get(parent_key, 0) + 1
             )
@@ -4137,9 +4116,7 @@ class GroupingStepWidget(QWidget):
         child_dirs_by_parent: dict[str, set[str]] = {}
         for directory in prepared_directories:
             directory_key = os.path.normcase(os.path.normpath(directory))
-            parent_key = os.path.normcase(
-                os.path.normpath(os.path.dirname(directory))
-            )
+            parent_key = os.path.normcase(os.path.normpath(os.path.dirname(directory)))
             child_dirs_by_parent.setdefault(parent_key, set()).add(directory_key)
 
         removable_dirs: set[str] = set()

--- a/src/ui/helpers/cluster_utils.py
+++ b/src/ui/helpers/cluster_utils.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from contextlib import suppress
 from datetime import datetime as datetime_obj
 from typing import Any
@@ -60,29 +59,32 @@ class ClusterUtils:
     def _resolve_image_datetime(
         path: str,
         date_cache: dict[str, datetime_obj | None],
+        file_data: dict[str, Any] | None = None,
     ) -> datetime_obj | None:
         """Resolve best-effort image datetime for sorting.
 
         Priority:
           1. Existing metadata date cache entry (typically EXIF/XMP creation date).
-          2. Filesystem birth time when available.
-          3. Filesystem modification time fallback.
+          2. Scanner-provided modification timestamp.
+
+        This helper runs during model sorting on the UI thread, so it must not
+        issue one filesystem stat call per image.
         """
         cached = date_cache.get(path)
         if cached is not None:
             return cached
 
-        try:
-            stat_result = os.stat(path)
-        except OSError:
-            return None
-
         timestamp: float | None = None
-        birth_time = getattr(stat_result, "st_birthtime", 0)
-        if birth_time and birth_time > 0:
-            timestamp = birth_time
-        if timestamp is None or timestamp < 1000000:
-            timestamp = stat_result.st_mtime
+        if isinstance(file_data, dict):
+            mtime_ns = file_data.get("mtime_ns")
+            mtime = file_data.get("mtime")
+            try:
+                if mtime_ns:
+                    timestamp = float(mtime_ns) / 1_000_000_000
+                elif mtime:
+                    timestamp = float(mtime)
+            except TypeError, ValueError:
+                timestamp = None
         if not timestamp:
             return None
 
@@ -103,7 +105,9 @@ class ClusterUtils:
                 path = file_data.get("path") if isinstance(file_data, dict) else None
                 if not path:
                     continue
-                img_date = ClusterUtils._resolve_image_datetime(path, date_cache)
+                img_date = ClusterUtils._resolve_image_datetime(
+                    path, date_cache, file_data
+                )
                 if img_date and img_date < earliest_date:
                     earliest_date = img_date
                     found_date = True

--- a/src/ui/helpers/index_lookup_utils.py
+++ b/src/ui/helpers/index_lookup_utils.py
@@ -1,6 +1,49 @@
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from PyQt6.QtCore import QModelIndex, Qt, QSortFilterProxyModel
 from PyQt6.QtGui import QStandardItemModel
+
+
+def find_proxy_indices_for_paths(
+    target_paths: Iterable[str],
+    proxy_model: QSortFilterProxyModel,
+    source_model: QStandardItemModel,
+    is_valid_image_item: Callable[[QModelIndex], bool],
+    is_expanded: Callable[[QModelIndex], bool] | None = None,
+) -> dict[str, QModelIndex]:
+    """Resolve many paths during one proxy-model traversal."""
+
+    remaining = {
+        path for path in target_paths if isinstance(path, str) and path
+    }
+    if not remaining or not isinstance(proxy_model, QSortFilterProxyModel):
+        return {}
+
+    matches: dict[str, QModelIndex] = {}
+    root_parent = QModelIndex()
+    queue = [
+        proxy_model.index(row, 0, root_parent)
+        for row in range(proxy_model.rowCount(root_parent))
+    ]
+    head = 0
+    while head < len(queue) and remaining:
+        current_proxy_idx = queue[head]
+        head += 1
+        if not current_proxy_idx.isValid():
+            continue
+        if is_valid_image_item(current_proxy_idx):
+            source_idx = proxy_model.mapToSource(current_proxy_idx)
+            item = source_model.itemFromIndex(source_idx)
+            data = item.data(Qt.ItemDataRole.UserRole) if item else None
+            path = data.get("path") if isinstance(data, dict) else None
+            if path in remaining:
+                matches[path] = current_proxy_idx
+                remaining.remove(path)
+        if is_expanded is None or is_expanded(current_proxy_idx):
+            queue.extend(
+                proxy_model.index(child_row, 0, current_proxy_idx)
+                for child_row in range(proxy_model.rowCount(current_proxy_idx))
+            )
+    return matches
 
 
 def find_proxy_index_for_path(
@@ -21,35 +64,13 @@ def find_proxy_index_for_path(
     Returns:
         QModelIndex for the proxy model if found else invalid QModelIndex().
     """
-    if not isinstance(proxy_model, QSortFilterProxyModel):  # Safety
-        return QModelIndex()
-
-    root_parent = QModelIndex()
-    queue = [
-        proxy_model.index(row, 0, root_parent)
-        for row in range(proxy_model.rowCount(root_parent))
-    ]
-
-    head = 0
-    while head < len(queue):
-        current_proxy_idx = queue[head]
-        head += 1
-        if not current_proxy_idx.isValid():
-            continue
-        if is_valid_image_item(current_proxy_idx):
-            source_idx = proxy_model.mapToSource(current_proxy_idx)
-            item = source_model.itemFromIndex(source_idx)
-            if item:
-                data = item.data(Qt.ItemDataRole.UserRole)
-                if isinstance(data, dict) and data.get("path") == target_path:
-                    return current_proxy_idx
-        # traverse children if tree-like
-        if is_expanded is None or is_expanded(current_proxy_idx):
-            queue.extend(
-                proxy_model.index(child_row, 0, current_proxy_idx)
-                for child_row in range(proxy_model.rowCount(current_proxy_idx))
-            )
-    return QModelIndex()
+    return find_proxy_indices_for_paths(
+        [target_path],
+        proxy_model,
+        source_model,
+        is_valid_image_item,
+        is_expanded,
+    ).get(target_path, QModelIndex())
 
 
 def classify_selection(selected_paths: list[str]):

--- a/src/ui/helpers/index_lookup_utils.py
+++ b/src/ui/helpers/index_lookup_utils.py
@@ -12,9 +12,7 @@ def find_proxy_indices_for_paths(
 ) -> dict[str, QModelIndex]:
     """Resolve many paths during one proxy-model traversal."""
 
-    remaining = {
-        path for path in target_paths if isinstance(path, str) and path
-    }
+    remaining = {path for path in target_paths if isinstance(path, str) and path}
     if not remaining or not isinstance(proxy_model, QSortFilterProxyModel):
         return {}
 

--- a/src/ui/helpers/statusbar_utils.py
+++ b/src/ui/helpers/statusbar_utils.py
@@ -47,11 +47,7 @@ def build_status_bar_info(
     cluster_id = None
     if cluster_lookup and file_path in cluster_lookup:
         cluster_id = cluster_lookup[file_path]
-    file_size = (
-        file_data_from_model.get("file_size")
-        if file_data_from_model
-        else None
-    )
+    file_size = file_data_from_model.get("file_size") if file_data_from_model else None
     try:
         size_kb = int(file_size) // 1024 if file_size is not None else None
     except TypeError, ValueError:

--- a/src/ui/helpers/statusbar_utils.py
+++ b/src/ui/helpers/statusbar_utils.py
@@ -47,9 +47,14 @@ def build_status_bar_info(
     cluster_id = None
     if cluster_lookup and file_path in cluster_lookup:
         cluster_id = cluster_lookup[file_path]
+    file_size = (
+        file_data_from_model.get("file_size")
+        if file_data_from_model
+        else None
+    )
     try:
-        size_kb = os.path.getsize(file_path) // 1024
-    except OSError:
+        size_kb = int(file_size) // 1024 if file_size is not None else None
+    except TypeError, ValueError:
         size_kb = None
     is_blurred = (
         file_data_from_model.get("is_blurred") if file_data_from_model else None

--- a/src/ui/helpers/ui_yield.py
+++ b/src/ui/helpers/ui_yield.py
@@ -1,0 +1,36 @@
+from collections.abc import Callable
+
+from PyQt6.QtCore import QCoreApplication, QEventLoop
+
+from core.app_settings import LARGE_FOLDER_THRESHOLD, UI_POPULATION_CHUNK_SIZE
+
+
+def cooperative_ui_yield(
+    processed: int,
+    total: int,
+    *,
+    progress_callback: Callable[[int, int], None] | None = None,
+) -> None:
+    """Repaint and deliver queued work during unavoidable bulk widget creation.
+
+    Qt model/widget objects must be created on the UI thread. For large
+    collections, yielding between bounded chunks keeps painting and worker
+    completion signals flowing while excluding new user input and socket
+    callbacks that could re-enter the active mutation.
+    """
+
+    if (
+        total <= LARGE_FOLDER_THRESHOLD
+        or processed <= 0
+        or processed % UI_POPULATION_CHUNK_SIZE
+    ):
+        return
+    if progress_callback is not None:
+        progress_callback(processed, total)
+    if QCoreApplication.instance() is None:
+        return
+    flags = (
+        QEventLoop.ProcessEventsFlag.ExcludeUserInputEvents
+        | QEventLoop.ProcessEventsFlag.ExcludeSocketNotifiers
+    )
+    QCoreApplication.processEvents(flags, 5)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -960,9 +960,7 @@ class MainWindow(QMainWindow):
         if (
             self.worker_manager.is_grouping_workflow_running()
             or self.worker_manager.is_rotation_application_running()
-            or getattr(
-                self.worker_manager, "is_file_deletion_running", lambda: False
-            )()
+            or getattr(self.worker_manager, "is_file_deletion_running", lambda: False)()
         ):
             self.statusBar().showMessage(
                 "Files are still being changed. Wait for the operation to finish before switching.",
@@ -1926,12 +1924,7 @@ class MainWindow(QMainWindow):
                 return
 
         represented_by_target = {
-            target: (
-                represented
-                if is_directory
-                else [target]
-            )
-            for target in targets
+            target: (represented if is_directory else [target]) for target in targets
         }
         self._start_deletion_batch(
             targets,
@@ -2463,10 +2456,7 @@ class MainWindow(QMainWindow):
             if (
                 user_data.startswith("cluster_header_")
                 or user_data.startswith("date_header_")
-                or (
-                    self.show_folders_mode
-                    and not self.group_by_similarity_mode
-                )
+                or (self.show_folders_mode and not self.group_by_similarity_mode)
             ):
                 is_group = True
 
@@ -2532,9 +2522,7 @@ class MainWindow(QMainWindow):
                 4000,
             )
             return
-        if getattr(
-            self.worker_manager, "is_file_deletion_running", lambda: False
-        )():
+        if getattr(self.worker_manager, "is_file_deletion_running", lambda: False)():
             event.ignore()
             self.statusBar().showMessage(
                 "Files are still moving to Trash. Wait for deletion to finish before closing.",
@@ -3127,9 +3115,9 @@ class MainWindow(QMainWindow):
             rating=self.app_state.rating_cache.get(normalized_path, 0),
             date=self.app_state.date_cache.get(normalized_path),
         )
-        raw_metadata = getattr(
-            self.app_state, "detailed_metadata_cache", {}
-        ).get(normalized_path)
+        raw_metadata = getattr(self.app_state, "detailed_metadata_cache", {}).get(
+            normalized_path
+        )
         if isinstance(raw_metadata, dict):
             label = raw_metadata.get("Xmp.xmp.Label")
             if label is not None:
@@ -3410,9 +3398,9 @@ class MainWindow(QMainWindow):
                 continue
 
             basic_metadata = self._get_cached_metadata_for_selection(path)
-            raw_exif = getattr(
-                self.app_state, "detailed_metadata_cache", {}
-            ).get(os.path.normpath(path))
+            raw_exif = getattr(self.app_state, "detailed_metadata_cache", {}).get(
+                os.path.normpath(path)
+            )
 
             images_data_for_viewer.append(
                 {
@@ -4668,9 +4656,7 @@ class MainWindow(QMainWindow):
         if not active_view:
             return False
         if self.worker_manager.is_file_deletion_running():
-            self.statusBar().showMessage(
-                "A deletion is already in progress.", 3000
-            )
+            self.statusBar().showMessage("A deletion is already in progress.", 3000)
             return False
 
         visible_paths_before = self._get_all_visible_image_paths()
@@ -4781,9 +4767,7 @@ class MainWindow(QMainWindow):
     def _handle_file_deletion_progress(
         self, current: int, total: int, filename: str
     ) -> None:
-        self.statusBar().showMessage(
-            f"Moving to Trash {current}/{total}: {filename}"
-        )
+        self.statusBar().showMessage(f"Moving to Trash {current}/{total}: {filename}")
 
     def _handle_file_deletion_complete(self, result) -> None:
         context = self._pending_deletion_context
@@ -4812,9 +4796,7 @@ class MainWindow(QMainWindow):
             clear_disk_caches=False,
         )
         if resolved_marks:
-            self.app_state.set_deletion_marks(
-                dict.fromkeys(resolved_marks, False)
-            )
+            self.app_state.set_deletion_marks(dict.fromkeys(resolved_marks, False))
         for path in deleted_paths:
             self.image_pipeline.invalidate_path(path)
         if deleted_paths:
@@ -4964,9 +4946,7 @@ class MainWindow(QMainWindow):
 
     def _finish_close_after_deletion(self) -> None:
         """Close only after the deletion worker thread has fully shut down."""
-        if getattr(
-            self.worker_manager, "is_file_deletion_running", lambda: False
-        )():
+        if getattr(self.worker_manager, "is_file_deletion_running", lambda: False)():
             QTimer.singleShot(25, self._finish_close_after_deletion)
             return
         self.close()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -57,7 +57,6 @@ from ui.controllers.image_inspection_controller import (
     ImageInspectionController,
     InspectionImageSpec,
 )
-from core.image_file_ops import ImageFileOperations
 from core.metadata_processor import MetadataProcessor  # New metadata processor
 from core.media_utils import is_video_extension
 from core.similarity_utils import cosine_similarity
@@ -88,7 +87,11 @@ from ui.workflow_transition import (
 )
 from ui.selection_utils import select_next_surviving_path
 from ui.helpers.statusbar_utils import build_status_bar_info
-from ui.helpers.index_lookup_utils import find_proxy_index_for_path
+from ui.helpers.index_lookup_utils import (
+    find_proxy_index_for_path,
+    find_proxy_indices_for_paths,
+)
+from ui.helpers.ui_yield import cooperative_ui_yield
 from ui.helpers.navigation_utils import (
     find_next_multi_image_cluster_head,
     find_next_rating_match,
@@ -143,7 +146,9 @@ class MainWindow(QMainWindow):
         self._filter_apply_count = 0
         self._last_filter_search_text: str | None = None
         self._close_after_grouping_save = False
+        self._close_after_deletion = False
         self._pending_workflow_transition: WorkflowTransitionRequest | None = None
+        self._pending_deletion_context: dict[str, Any] | None = None
 
         self.image_pipeline = ImagePipeline()
         self.app_state = AppState()
@@ -655,6 +660,12 @@ class MainWindow(QMainWindow):
     def _connect_signals(self):
         start_time = time.perf_counter()
         logger.debug("Connecting signals...")
+        self.worker_manager.file_deletion_progress.connect(
+            self._handle_file_deletion_progress
+        )
+        self.worker_manager.file_deletion_complete.connect(
+            self._handle_file_deletion_complete
+        )
         # Connect to the new signals from the advanced viewer
         self.advanced_image_viewer.ratingChanged.connect(self._apply_rating)
         self.advanced_image_viewer.deleteRequested.connect(self._delete_image)
@@ -913,6 +924,7 @@ class MainWindow(QMainWindow):
         rotations: dict[str, int] = {}
         if source == "fix_rotation" and self.fix_rotation_step_widget is not None:
             rotations = self.fix_rotation_step_widget.pending_rotations()
+        directory_paths = self.grouping_step_widget.known_directory_paths()
         return WorkflowPendingState(
             organize_actions=organize_actions,
             organize_delete_paths=organize_delete_paths,
@@ -920,6 +932,7 @@ class MainWindow(QMainWindow):
             rotation_count=len(rotations),
             rotation_changes=rotations,
             trash_paths=self.app_state.get_marked_files(),
+            directory_paths=directory_paths,
         )
 
     def _has_blocking_review_edit(self, workflow_step: str) -> bool:
@@ -947,6 +960,9 @@ class MainWindow(QMainWindow):
         if (
             self.worker_manager.is_grouping_workflow_running()
             or self.worker_manager.is_rotation_application_running()
+            or getattr(
+                self.worker_manager, "is_file_deletion_running", lambda: False
+            )()
         ):
             self.statusBar().showMessage(
                 "Files are still being changed. Wait for the operation to finish before switching.",
@@ -1032,7 +1048,13 @@ class MainWindow(QMainWindow):
             return False
         if request.trash_resolution == "commit":
             marked = self.app_state.get_marked_files()
-            if marked and not self._perform_deletion_of_marked_files(marked):
+            deletion_result = (
+                self._perform_deletion_of_marked_files(marked) if marked else True
+            )
+            if deletion_result is None:
+                self._pending_workflow_transition = request
+                return False
+            if not deletion_result:
                 self._pending_workflow_transition = None
                 self.statusBar().showMessage(
                     "Some marked files could not be moved to Trash. Resolve them before switching.",
@@ -1249,6 +1271,8 @@ class MainWindow(QMainWindow):
             preserved_focused_path = self.app_state.focused_image_path
 
         self.update_loading_text("Rebuilding view...")
+        self._model_population_processed = 0
+        self._model_population_total = len(self.app_state.image_files_data)
         # Drop Python wrappers before Qt deletes their underlying model items.
         # Queued thumbnail callbacks may run re-entrantly during UI updates.
         self._file_items_by_path.clear()
@@ -1397,15 +1421,17 @@ class MainWindow(QMainWindow):
             active_view.updateGeometries()
             active_view.viewport().update()
 
-            focused_proxy_idx = (
-                self._find_proxy_index_for_path(preserved_focused_path)
-                if preserved_focused_path
-                else QModelIndex()
+            restore_paths = list(preserved_selection_paths)
+            if preserved_focused_path:
+                restore_paths.append(preserved_focused_path)
+            restore_indices = self._find_proxy_indices_for_paths(restore_paths)
+            focused_proxy_idx = restore_indices.get(
+                preserved_focused_path, QModelIndex()
             )
 
             selection_to_restore = QItemSelection()
             for path in preserved_selection_paths:
-                proxy_idx = self._find_proxy_index_for_path(path)
+                proxy_idx = restore_indices.get(path, QModelIndex())
                 if proxy_idx.isValid():
                     selection_to_restore.select(proxy_idx, proxy_idx)
 
@@ -1454,6 +1480,8 @@ class MainWindow(QMainWindow):
                         active_view.expand(idx_to_expand)
 
         self._cull_model_dirty = False
+        self._model_population_processed = 0
+        self._model_population_total = 0
         thumbnail_loader = getattr(self, "thumbnail_loader", None)
         if thumbnail_loader is not None:
             # The model owns new item objects now. Re-request only its viewport
@@ -1655,7 +1683,7 @@ class MainWindow(QMainWindow):
             widget.set_has_any_marked_func(
                 lambda: bool(self.app_state.marked_for_deletion)
             )
-            widget.set_exif_disk_cache(self.app_state.exif_disk_cache)
+            widget.set_exif_disk_cache(self.app_state.detailed_metadata_cache)
             widget.skip_requested.connect(
                 lambda: self._request_next_visible_workflow_transition("easy_delete")
             )
@@ -1834,32 +1862,37 @@ class MainWindow(QMainWindow):
                 widget.refresh_deletion_state()
 
     def _toggle_organize_deletion_marks(self, paths: list[str]) -> None:
-        existing_paths = [
-            path
-            for path in dict.fromkeys(paths)
-            if os.path.isfile(path) or os.path.isdir(path)
-        ]
-        contains_directory = any(os.path.isdir(path) for path in existing_paths)
-        toggled = 0
+        existing_paths = list(dict.fromkeys(path for path in paths if path))
+        directory_paths = self.grouping_step_widget.known_directory_paths()
+        normalized_directories = {
+            os.path.normcase(os.path.normpath(path)) for path in directory_paths
+        }
+        contains_directory = any(
+            os.path.normcase(os.path.normpath(path)) in normalized_directories
+            for path in existing_paths
+        )
+        mark_state: dict[str, bool] = {}
         if contains_directory:
             should_unmark = all(
                 self.app_state.is_marked_for_deletion(path) for path in existing_paths
             )
-            for path in existing_paths:
-                if should_unmark:
-                    self.deletion_controller.unmark(path)
-                else:
-                    self.deletion_controller.mark(path)
-                toggled += 1
+            mark_state = dict.fromkeys(existing_paths, not should_unmark)
         else:
-            for path in existing_paths:
-                self.deletion_controller.toggle_mark(path)
-                toggled += 1
+            mark_state = {
+                path: not self.app_state.is_marked_for_deletion(path)
+                for path in existing_paths
+            }
+        toggled = len(mark_state)
         if not toggled:
             self.statusBar().showMessage(
                 "No files or folders are available to mark.", 3000
             )
             return
+        self.deletion_controller.set_paths_marked(
+            mark_state,
+            self.file_system_model,
+            self.proxy_model,
+        )
         self.proxy_model.invalidate()
         self._refresh_visible_items_icons()
         self._refresh_workflow_deletion_state()
@@ -1869,7 +1902,15 @@ class MainWindow(QMainWindow):
         self, target_path: str, represented_paths: list[str]
     ) -> None:
         represented = list(dict.fromkeys(represented_paths))
-        is_directory = bool(target_path and os.path.isdir(target_path))
+        directory_paths = self.grouping_step_widget.known_directory_paths()
+        normalized_directories = {
+            os.path.normcase(os.path.normpath(path)) for path in directory_paths
+        }
+        is_directory = bool(
+            target_path
+            and os.path.normcase(os.path.normpath(target_path))
+            in normalized_directories
+        )
         if is_directory:
             if not self.dialog_manager.show_confirm_trash_target_dialog(
                 target_path, represented
@@ -1878,38 +1919,32 @@ class MainWindow(QMainWindow):
             targets = [target_path]
         else:
             targets = [target_path] if target_path else represented
-            targets = [path for path in targets if os.path.isfile(path)]
+            targets = list(dict.fromkeys(path for path in targets if path))
             if not targets or not self.dialog_manager.show_confirm_delete_dialog(
                 targets
             ):
                 return
 
-        successful_paths: list[str] = []
-        failures: list[str] = []
-        for path in targets:
-            success, message = ImageFileOperations.move_to_trash(path)
-            if success:
-                successful_paths.extend(represented if is_directory else [path])
-            else:
-                failures.append(message or os.path.basename(path))
-
-        successful_paths = list(dict.fromkeys(successful_paths))
-        if successful_paths:
-            for path in successful_paths:
-                self.app_state.remove_data_for_path(path)
-                self.image_pipeline.invalidate_path(path)
-            self.thumbnail_loader.invalidate_paths(successful_paths)
-            self.grouping_step_widget.remove_deleted_paths(successful_paths)
-            self.proxy_model.invalidate()
-            self.mark_cull_model_dirty()
-            self._refresh_workflow_deletion_state()
-            self.statusBar().showMessage(
-                f"Moved {len(successful_paths)} file(s) to Trash.", 5000
+        represented_by_target = {
+            target: (
+                represented
+                if is_directory
+                else [target]
             )
-        if failures:
-            self.dialog_manager.show_error_dialog(
-                "Trash Error", "\n".join(failures[:5])
-            )
+            for target in targets
+        }
+        self._start_deletion_batch(
+            targets,
+            represented_by_target,
+            completion=lambda successful, deleted, failures, _resolved: (
+                self._finish_ad_hoc_deletion(
+                    successful,
+                    deleted,
+                    failures,
+                    operation_label="Trash",
+                )
+            ),
+        )
 
     def _mark_paths_for_deletion(self, paths: list) -> None:
         self.deletion_controller.mark_paths(
@@ -2092,18 +2127,26 @@ class MainWindow(QMainWindow):
             item = QStandardItem(os.path.basename(path))
             item.setData({"path": path, "rotation": rotation}, Qt.ItemDataRole.UserRole)
             root_item.appendRow(item)
+            self._note_model_item_populated()
+
+    def _note_model_item_populated(self) -> None:
+        self._model_population_processed = (
+            getattr(self, "_model_population_processed", 0) + 1
+        )
+        total = getattr(self, "_model_population_total", 0)
+        cooperative_ui_yield(
+            self._model_population_processed,
+            total,
+            progress_callback=lambda processed, count: self.update_loading_text(
+                f"Populating view: {processed}/{count}..."
+            ),
+        )
 
     def _populate_model_standard(
         self, parent_item: QStandardItem, image_data_list: list[dict[str, Any]]
     ):
         if not image_data_list:
             return
-
-        from core.app_settings import LARGE_FOLDER_THRESHOLD, UI_POPULATION_CHUNK_SIZE
-
-        total_items = len(image_data_list)
-        use_chunked_processing = total_items > LARGE_FOLDER_THRESHOLD
-        processed_count = 0
 
         if self.show_folders_mode and not self.group_by_similarity_mode:
             files_by_folder: dict[str, list[dict[str, Any]]] = {}
@@ -2130,17 +2173,7 @@ class MainWindow(QMainWindow):
                 ):
                     image_item = self._create_standard_item(file_data)
                     folder_item.appendRow(image_item)
-
-                    if use_chunked_processing:
-                        processed_count += 1
-                        if processed_count % UI_POPULATION_CHUNK_SIZE == 0:
-                            progress_msg = (
-                                f"Populating view: {processed_count}/{total_items}..."
-                            )
-                            self.update_loading_text(progress_msg)
-                            logger.info(
-                                progress_msg
-                            )  # Log progress so user can see what's happening
+                    self._note_model_item_populated()
         else:  # Not showing folders, or grouping by similarity (which creates its own top-level groups)
 
             def image_sort_key_func(fd):
@@ -2167,22 +2200,10 @@ class MainWindow(QMainWindow):
             for file_data in sorted(image_data_list, key=image_sort_key_func):
                 image_item = self._create_standard_item(file_data)
                 parent_item.appendRow(image_item)
-
-                if use_chunked_processing:
-                    processed_count += 1
-                    if processed_count % UI_POPULATION_CHUNK_SIZE == 0:
-                        progress_msg = (
-                            f"Populating view: {processed_count}/{total_items}..."
-                        )
-                        self.update_loading_text(progress_msg)
-                        logger.info(
-                            progress_msg
-                        )  # Log progress so user can see what's happening
+                self._note_model_item_populated()
 
     def _apply_rating(self, file_path: str, rating: int):
         """Handle a viewer rating request through the shared background worker."""
-        if not os.path.exists(file_path):
-            return
         # Use the background worker for all rating operations
         self.app_controller.apply_rating_to_selection(rating, [file_path])
 
@@ -2206,73 +2227,65 @@ class MainWindow(QMainWindow):
     def _delete_image(self, file_path: str):
         """Delete a single image file."""
         logger.debug(f"Deleting image: {file_path}")
-        if not os.path.exists(file_path):
-            logger.warning(f"File does not exist: {file_path}")
-            return
 
         # Show confirmation dialog
         if not self.dialog_manager.show_confirm_delete_dialog([file_path]):
             logger.debug("User cancelled deletion")
             return
 
-        # Move to trash
-        logger.info(f"Moving file to trash: {file_path}")
-        success, message = ImageFileOperations.move_to_trash(file_path)
-        if success:
-            # Remove from app state
-            self.app_state.remove_data_for_path(file_path)
-            self.statusBar().showMessage(f"Deleted {os.path.basename(file_path)}", 5000)
-            logger.info(f"Successfully deleted: {file_path}")
-            # Refresh the view
-            self._handle_file_selection_changed()
-            # Reapply filters to hide deleted items
-            self._apply_filter()
-        else:
-            self.statusBar().showMessage(
-                f"Failed to delete {os.path.basename(file_path)}: {message}", 5000
-            )
-            logger.error(f"Failed to delete {file_path}: {message}")
+        self._start_deletion_batch(
+            [file_path],
+            {file_path: [file_path]},
+            completion=lambda successful, deleted, failures, _resolved: (
+                self._finish_ad_hoc_deletion(successful, deleted, failures)
+            ),
+        )
 
     def _delete_multiple_images(self, file_paths: list[str]):
         """Delete multiple image files at once."""
         logger.debug(f"Deleting multiple images: {file_paths}")
 
-        # Filter out non-existent files
-        existing_file_paths = [path for path in file_paths if os.path.exists(path)]
-        if not existing_file_paths:
+        target_paths = list(dict.fromkeys(path for path in file_paths if path))
+        if not target_paths:
             logger.warning("No valid files to delete")
             return
 
         # Show confirmation dialog for all files at once
-        if not self.dialog_manager.show_confirm_delete_dialog(existing_file_paths):
+        if not self.dialog_manager.show_confirm_delete_dialog(target_paths):
             logger.debug("User cancelled deletion")
             return
 
-        # Delete each file
-        deleted_count = 0
-        for file_path in existing_file_paths:
-            logger.info(f"Moving file to trash: {file_path}")
-            success, message = ImageFileOperations.move_to_trash(file_path)
-            if success:
-                # Remove from app state
-                self.app_state.remove_data_for_path(file_path)
-                logger.info(f"Successfully deleted: {file_path}")
-                deleted_count += 1
-            else:
-                self.statusBar().showMessage(
-                    f"Failed to delete {os.path.basename(file_path)}: {message}", 5000
-                )
-                logger.error(f"Failed to delete {file_path}: {message}")
+        self._start_deletion_batch(
+            target_paths,
+            {path: [path] for path in target_paths},
+            completion=lambda successful, deleted, failures, _resolved: (
+                self._finish_ad_hoc_deletion(successful, deleted, failures)
+            ),
+        )
 
-        # Show status message
-        if deleted_count > 0:
-            self.statusBar().showMessage(f"Deleted {deleted_count} image(s)", 5000)
-            # Refresh the view
+    def _finish_ad_hoc_deletion(
+        self,
+        successful_targets: list[str],
+        deleted_paths: list[str],
+        failures: dict[str, str],
+        *,
+        operation_label: str = "Delete",
+    ) -> None:
+        if deleted_paths:
+            self.statusBar().showMessage(
+                f"Moved {len(successful_targets)} item(s) to Trash.", 5000
+            )
             self._handle_file_selection_changed()
-            # Reapply filters to hide deleted items
-            self._apply_filter()
-        elif len(existing_file_paths) > 0:
-            self.statusBar().showMessage("Failed to delete any images", 5000)
+            self._update_image_info_label()
+        if failures:
+            details = "\n".join(
+                f"{os.path.basename(path) or path}: {message}"
+                for path, message in list(failures.items())[:5]
+            )
+            self.dialog_manager.show_error_dialog(
+                f"{operation_label} Error",
+                details,
+            )
 
     def _log_qmodelindex(self, index: QModelIndex, prefix: str = "") -> str:
         if not index.isValid():
@@ -2301,13 +2314,10 @@ class MainWindow(QMainWindow):
             return False
 
         item_user_data = item.data(Qt.ItemDataRole.UserRole)
-        is_image = (
-            isinstance(item_user_data, dict)
-            and "path" in item_user_data
-            and os.path.isfile(item_user_data["path"])
-        )
-
-        return is_image
+        # The scanner-backed model is the source of truth here. Calling
+        # ``isfile`` while traversing the model turns selection and navigation
+        # into one filesystem round trip per row on slow/network volumes.
+        return isinstance(item_user_data, dict) and bool(item_user_data.get("path"))
 
     def _get_active_file_view(self):
         return self.left_panel.get_active_view() if self.left_panel else None
@@ -2456,7 +2466,6 @@ class MainWindow(QMainWindow):
                 or (
                     self.show_folders_mode
                     and not self.group_by_similarity_mode
-                    and os.path.isdir(user_data)
                 )
             ):
                 is_group = True
@@ -2523,10 +2532,18 @@ class MainWindow(QMainWindow):
                 4000,
             )
             return
+        if getattr(
+            self.worker_manager, "is_file_deletion_running", lambda: False
+        )():
+            event.ignore()
+            self.statusBar().showMessage(
+                "Files are still moving to Trash. Wait for deletion to finish before closing.",
+                4000,
+            )
+            return
 
-        # The detailed action preview walks the complete source tree. Most closes
-        # have no Organize edits, so compare the in-memory plan signature first
-        # and only perform filesystem work when a dialog is actually required.
+        # Compare the in-memory signature before building the worker-inventoried
+        # action preview. No source-tree walk occurs on the UI thread.
         has_grouping_edits = self.grouping_step_widget.has_unsaved_grouping_edits()
         grouping_action_lines = (
             self.grouping_step_widget.pending_grouping_action_lines()
@@ -2561,9 +2578,12 @@ class MainWindow(QMainWindow):
 
             if choice == "commit":
                 logger.info("User chose to commit deletions on close")
-                # Commit the deletions and then close
-                self._commit_marked_deletions_without_confirmation()
-                # Continue with closing
+                self._close_after_deletion = True
+                started = self._commit_marked_deletions_without_confirmation()
+                if started is False:
+                    self._close_after_deletion = False
+                event.ignore()
+                return
             elif choice == "ignore":
                 logger.info("User chose to ignore deletions on close")
                 # Ignore the marked files and close
@@ -3061,9 +3081,26 @@ class MainWindow(QMainWindow):
             proxy_model=proxy_model,
             source_model=self.file_system_model,
             is_valid_image_item=self._is_valid_image_item,
-            is_expanded=(lambda idx: active_view.isExpanded(idx))
-            if isinstance(active_view, QTreeView)
-            else None,
+            is_expanded=None,
+        )
+
+    def _find_proxy_indices_for_paths(
+        self, target_paths: list[str] | set[str]
+    ) -> dict[str, QModelIndex]:
+        """Resolve a path collection without repeatedly walking the model."""
+
+        active_view = self._get_active_file_view()
+        if not active_view:
+            return {}
+        proxy_model = active_view.model()
+        if not isinstance(proxy_model, QSortFilterProxyModel):
+            return {}
+        return find_proxy_indices_for_paths(
+            target_paths=target_paths,
+            proxy_model=proxy_model,
+            source_model=self.file_system_model,
+            is_valid_image_item=self._is_valid_image_item,
+            is_expanded=None,
         )
 
     def _get_selected_file_paths_from_view(self) -> list[str]:
@@ -3076,22 +3113,28 @@ class MainWindow(QMainWindow):
     def _get_cached_metadata_for_selection(
         self, file_path: str
     ) -> dict[str, Any] | None:
-        """Gets metadata from AppState caches. Assumes caches are populated by RatingLoaderWorker."""
-        if not os.path.isfile(file_path):
-            logger.warning(
-                f"[_get_cached_metadata_for_selection] File not found: {file_path}"
-            )
-            return None
+        """Return scanner/worker-populated metadata without filesystem access."""
 
-        # Data should have been populated by RatingLoaderWorker into AppState caches
-        # os.path.normpath is important for cache key consistency.
-        # RatingLoaderWorker stores with normalized paths.
         normalized_path = os.path.normpath(file_path)
-
-        current_rating = self.app_state.rating_cache.get(normalized_path, 0)
-        current_date = self.app_state.date_cache.get(normalized_path)
-
-        return {"rating": current_rating, "date": current_date}
+        get_file_data = getattr(self.app_state, "get_file_data_by_path", None)
+        file_data = (
+            get_file_data(file_path) or get_file_data(normalized_path)
+            if callable(get_file_data)
+            else None
+        )
+        metadata = dict(file_data or {})
+        metadata.update(
+            rating=self.app_state.rating_cache.get(normalized_path, 0),
+            date=self.app_state.date_cache.get(normalized_path),
+        )
+        raw_metadata = getattr(
+            self.app_state, "detailed_metadata_cache", {}
+        ).get(normalized_path)
+        if isinstance(raw_metadata, dict):
+            label = raw_metadata.get("Xmp.xmp.Label")
+            if label is not None:
+                metadata["label"] = label
+        return metadata
 
     def _display_single_image_preview(
         self, file_path: str, file_data_from_model: dict[str, Any] | None
@@ -3099,14 +3142,6 @@ class MainWindow(QMainWindow):
         """Handles displaying preview and info for a single selected image."""
         self._pending_rotation_comparison_path = None
         logger.debug(f"Displaying single image preview: {os.path.basename(file_path)}")
-        if not os.path.exists(file_path):
-            logger.warning(f"File not found: {file_path}")
-            self.advanced_image_viewer.clear()
-            self.statusBar().showMessage(
-                f"Error: File not found - {os.path.basename(file_path)}", 5000
-            )
-            self.invalidate_last_displayed_preview()
-            return
 
         metadata = self._get_cached_metadata_for_selection(file_path)
         if not metadata:
@@ -3247,13 +3282,6 @@ class MainWindow(QMainWindow):
         file_data_from_model: dict[str, Any] | None,
     ):
         logger.debug(f"Displaying single video preview: {os.path.basename(file_path)}")
-        if not os.path.exists(file_path):
-            self.advanced_image_viewer.clear()
-            self.statusBar().showMessage(
-                f"Error: File not found - {os.path.basename(file_path)}", 5000
-            )
-            self.invalidate_last_displayed_preview()
-            return
 
         self.activate_image_inspection(
             self.advanced_image_viewer,
@@ -3282,13 +3310,6 @@ class MainWindow(QMainWindow):
     ):
         """Handles displaying preview after rotation, preserving view mode."""
         logger.debug(f"Displaying rotated image preview: {os.path.basename(file_path)}")
-        if not os.path.exists(file_path):
-            self.advanced_image_viewer.clear()
-            self.statusBar().showMessage(
-                f"Error: File not found - {os.path.basename(file_path)}", 5000
-            )
-            self.invalidate_last_displayed_preview()
-            return
 
         if preserve_side_by_side:
             # In side-by-side mode, we need to refresh the entire view to show the updated image
@@ -3389,9 +3410,9 @@ class MainWindow(QMainWindow):
                 continue
 
             basic_metadata = self._get_cached_metadata_for_selection(path)
-            raw_exif = MetadataProcessor.get_cached_detailed_metadata(
-                path, self.app_state.exif_disk_cache
-            )
+            raw_exif = getattr(
+                self.app_state, "detailed_metadata_cache", {}
+            ).get(os.path.normpath(path))
 
             images_data_for_viewer.append(
                 {
@@ -3812,6 +3833,7 @@ class MainWindow(QMainWindow):
                 for file_data in files_in_group_data:
                     image_item = self._create_standard_item(file_data)
                     parent_for_images.appendRow(image_item)
+                    self._note_model_item_populated()
 
     def _create_standard_item(self, file_data: dict[str, Any]):
         file_path = file_data["path"]
@@ -4008,11 +4030,8 @@ class MainWindow(QMainWindow):
             item_data = item.data(Qt.ItemDataRole.UserRole)
             if isinstance(item_data, dict) and "path" in item_data:
                 image_path = item_data["path"]
-                if os.path.exists(image_path):
-                    determined_cluster_id = self.app_state.cluster_results.get(
-                        image_path
-                    )
-                    break
+                determined_cluster_id = self.app_state.cluster_results.get(image_path)
+                break
             elif isinstance(item_data, str) and item_data.startswith("cluster_header_"):
                 with contextlib.suppress(ValueError, IndexError):
                     determined_cluster_id = int(item_data.split("_")[-1])
@@ -4469,12 +4488,6 @@ class MainWindow(QMainWindow):
             f"_update_sidebar_with_current_selection: Processing {os.path.basename(file_path)} (extension: {file_ext})"
         )
 
-        if not os.path.exists(file_path):
-            logger.error(
-                f"_update_sidebar_with_current_selection: File does not exist: {file_path}"
-            )
-            return
-
         # Get cached metadata
         metadata = self._get_cached_metadata_for_selection(file_path)
         if not metadata:
@@ -4490,11 +4503,8 @@ class MainWindow(QMainWindow):
         # Detailed metadata is populated by the folder's batch metadata worker.
         # A selection change must remain cache-only so a slow RAW/video parser can
         # never block navigation on the UI thread.
-        raw_exif = (
-            MetadataProcessor.get_cached_detailed_metadata(
-                file_path, self.app_state.exif_disk_cache
-            )
-            or {}
+        raw_exif = self.app_state.detailed_metadata_cache.get(
+            os.path.normpath(file_path), {}
         )
 
         # Update sidebar
@@ -4653,15 +4663,20 @@ class MainWindow(QMainWindow):
         self._perform_deletion_of_marked_files(marked_files)
 
     def _perform_deletion_of_marked_files(self, marked_files: list[str]):
-        """Performs the actual deletion of marked files, updating the view in-place."""
+        """Start one background Trash batch for all effective marked targets."""
         active_view = self._get_active_file_view()
         if not active_view:
             return False
+        if self.worker_manager.is_file_deletion_running():
+            self.statusBar().showMessage(
+                "A deletion is already in progress.", 3000
+            )
+            return False
 
-        # --- Pre-computation for next selection ---
         visible_paths_before = self._get_all_visible_image_paths()
-        logger.debug(f"Visible paths before deletion: {visible_paths_before}")
-        logger.debug(f"Marked files for deletion: {marked_files}")
+        current_selected_path_before = (
+            self.app_state.focused_image_path or self._get_current_selected_image_path()
+        )
 
         def is_within(path: str, directory: str) -> bool:
             try:
@@ -4673,7 +4688,15 @@ class MainWindow(QMainWindow):
             except ValueError, OSError:
                 return False
 
-        directory_targets = [path for path in marked_files if os.path.isdir(path)]
+        known_directories = {
+            os.path.normcase(os.path.normpath(path))
+            for path in self.grouping_step_widget.known_directory_paths()
+        }
+        directory_targets = [
+            path
+            for path in marked_files
+            if os.path.normcase(os.path.normpath(path)) in known_directories
+        ]
         effective_targets = [
             path
             for path in marked_files
@@ -4682,154 +4705,123 @@ class MainWindow(QMainWindow):
                 for directory in directory_targets
             )
         ]
-
-        # --- Delete files and update model ---
-        deleted_count = 0
-        successfully_deleted: list[str] = []
-        resolved_marks: set[str] = set()
-        for file_path in effective_targets:
-            is_directory_target = os.path.isdir(file_path)
-            represented_paths = [file_path]
-            if is_directory_target:
-                represented_paths = [
-                    item.get("path")
-                    for item in self.app_state.image_files_data
-                    if item.get("path") and is_within(item["path"], file_path)
+        represented_by_target: dict[str, list[str]] = {}
+        marks_by_target: dict[str, list[str]] = {}
+        media_paths = [
+            item.get("path")
+            for item in self.app_state.image_files_data
+            if item.get("path")
+        ]
+        for target in effective_targets:
+            if os.path.normcase(os.path.normpath(target)) in known_directories:
+                represented_by_target[target] = [
+                    path for path in media_paths if is_within(path, target)
                 ]
-            try:
-                success, message = self.app_controller.move_to_trash(file_path)
-                if not success:
-                    raise RuntimeError(message)
-                for represented_path in represented_paths:
-                    self.app_state.remove_data_for_path(represented_path)
-                deleted_count += 1
-                successfully_deleted.extend(represented_paths)
-                resolved_marks.update(
+                marks_by_target[target] = [
                     marked
                     for marked in marked_files
-                    if marked == file_path
-                    or (is_directory_target and is_within(marked, file_path))
-                )
-                logger.info(f"Moved file to trash: {os.path.basename(file_path)}")
-            except Exception as e:
-                logger.error(f"Error moving marked file '{file_path}' to trash: {e}")
-
-        successfully_deleted = list(dict.fromkeys(successfully_deleted))
-        for file_path in resolved_marks:
-            self.app_state.unmark_for_deletion(file_path)
-        for file_path in successfully_deleted:
-            self.image_pipeline.invalidate_path(file_path)
-        if successfully_deleted:
-            self.thumbnail_loader.invalidate_paths(successfully_deleted)
-
-        # Rebuild row removals from successful paths only; failed files stay visible.
-        source_indices_by_parent = {}
-        for path in successfully_deleted:
-            proxy_idx = self._find_proxy_index_for_path(path)
-            if proxy_idx.isValid():
-                source_idx = self.proxy_model.mapToSource(proxy_idx)
-                parent_idx = source_idx.parent()
-                source_indices_by_parent.setdefault(parent_idx, []).append(
-                    source_idx.row()
-                )
-
-        if deleted_count > 0:
-            for parent_idx, rows in source_indices_by_parent.items():
-                parent_item = (
-                    self.file_system_model.itemFromIndex(parent_idx)
-                    if parent_idx.isValid()
-                    else self.file_system_model.invisibleRootItem()
-                )
-                if parent_item:
-                    for row in sorted(rows, reverse=True):
-                        parent_item.takeRow(row)
-
-            self.proxy_model.invalidate()
-            self.statusBar().showMessage(f"Committed {deleted_count} deletions.", 5000)
-
-            # --- Select next item using robust advancement to next valid image ---
-            visible_paths_after_delete = self._get_all_visible_image_paths()
-            logger.debug(
-                f"{len(visible_paths_after_delete)} visible paths remaining after deletion."
-            )
-            logger.debug("Visible paths after deletion list suppressed for brevity")
-
-            # Determine the anchor path for selection after deletion
-            # This determines which image position to use as reference for finding the next selection
-            current_selected_path_before = (
-                self.app_state.focused_image_path
-                or self._get_current_selected_image_path()
-            )
-
-            # If the current selection is one of the deleted files, use it as anchor
-            # This will ensure we select the next image after the deleted one
-            if current_selected_path_before in successfully_deleted:
-                anchor_path = current_selected_path_before
-            # If there are deleted files and current selection is not one of them,
-            # use the first deleted file as anchor for better UX
-            # This handles cases where user marks files for deletion without having them selected
-            elif successfully_deleted:
-                anchor_path = successfully_deleted[
-                    0
-                ]  # Use first deleted file as reference point
-            # Fallback to current selection
+                    if marked == target or is_within(marked, target)
+                ]
             else:
-                anchor_path = current_selected_path_before
+                represented_by_target[target] = [target]
+                marks_by_target[target] = [target]
 
-            logger.debug(
-                f"Current selected (focused) path before deletion: {current_selected_path_before}"
-            )
-            logger.debug(f"Anchor path for selection after deletion: {anchor_path}")
-
-            if not visible_paths_after_delete:
-                logger.debug("No visible image items left after deletion.")
-                self.advanced_image_viewer.clear()
-                self.advanced_image_viewer.setText("No images left to display.")
-                self.statusBar().showMessage("No images left or visible.")
-            else:
-                # Always find the best next selection. The function is smart enough
-                # to keep the current selection if it's still valid.
-                logger.debug("Finding next selection after deletion.")
-                next_path = select_next_surviving_path(
+        started = self._start_deletion_batch(
+            effective_targets,
+            represented_by_target,
+            marks_by_target=marks_by_target,
+            completion=lambda successful_targets, deleted_paths, failures, resolved: (
+                self._finish_marked_deletion_batch(
                     visible_paths_before,
-                    successfully_deleted,
-                    anchor_path,
-                    visible_paths_after_delete,
+                    current_selected_path_before,
+                    marked_files,
+                    successful_targets,
+                    deleted_paths,
+                    failures,
+                    resolved,
                 )
+            ),
+        )
+        return None if started else False
 
-                if next_path:
-                    next_proxy_idx = self._find_proxy_index_for_path(next_path)
-                    if next_proxy_idx.isValid():
-                        logger.debug("Selecting next path after deletion")
-                        active_view.setCurrentIndex(next_proxy_idx)
-                        active_view.selectionModel().select(
-                            next_proxy_idx,
-                            QItemSelectionModel.SelectionFlag.ClearAndSelect,
-                        )
-                        active_view.scrollTo(
-                            next_proxy_idx,
-                            QAbstractItemView.ScrollHint.EnsureVisible,
-                        )
-                        # The selection change will trigger the preview update.
-                        # We might need to manually trigger if the selection doesn't change
-                        # but this is safer.
-                        QTimer.singleShot(0, self._handle_file_selection_changed)
-                    else:
-                        logger.warning(
-                            f"Could not find a valid proxy index for the next path: {next_path}"
-                        )
-                        self.advanced_image_viewer.clear()
-                        self.advanced_image_viewer.setText(
-                            "Could not select next image."
-                        )
-                else:
-                    logger.debug("No next valid path found; clearing UI.")
-                    self.advanced_image_viewer.clear()
-                    self.advanced_image_viewer.setText("No valid image to select.")
+    def _start_deletion_batch(
+        self,
+        targets: list[str],
+        represented_by_target: dict[str, list[str]],
+        *,
+        marks_by_target: dict[str, list[str]] | None = None,
+        completion: Callable[[list[str], list[str], dict[str, str], set[str]], None],
+    ) -> bool:
+        if self._pending_deletion_context is not None:
+            return False
+        normalized_targets = list(dict.fromkeys(path for path in targets if path))
+        if not normalized_targets:
+            return False
+        self._pending_deletion_context = {
+            "represented_by_target": represented_by_target,
+            "marks_by_target": marks_by_target or {},
+            "completion": completion,
+        }
+        started = self.worker_manager.start_file_deletion(
+            normalized_targets,
+            cache_paths_by_target=represented_by_target,
+            rating_cache=self.app_state.rating_disk_cache,
+            exif_cache=self.app_state.exif_disk_cache,
+            analysis_cache=self.app_state.analysis_cache,
+            folder_path=self.app_state.current_folder_path,
+        )
+        if not started:
+            self._pending_deletion_context = None
+            return False
+        self.statusBar().showMessage(
+            f"Moving {len(normalized_targets)} item(s) to Trash…"
+        )
+        return True
 
-            self._update_image_info_label()
+    def _handle_file_deletion_progress(
+        self, current: int, total: int, filename: str
+    ) -> None:
+        self.statusBar().showMessage(
+            f"Moving to Trash {current}/{total}: {filename}"
+        )
 
-            self.grouping_step_widget.remove_deleted_paths(successfully_deleted)
+    def _handle_file_deletion_complete(self, result) -> None:
+        context = self._pending_deletion_context
+        self._pending_deletion_context = None
+        if context is None:
+            return
+        successful_targets = list(getattr(result, "successful_targets", []))
+        failures = dict(getattr(result, "failures", {}))
+        represented_by_target = context["represented_by_target"]
+        marks_by_target = context["marks_by_target"]
+        deleted_paths = list(
+            dict.fromkeys(
+                path
+                for target in successful_targets
+                for path in represented_by_target.get(target, [target])
+            )
+        )
+        resolved_marks = {
+            path
+            for target in successful_targets
+            for path in marks_by_target.get(target, [])
+        }
+
+        self.app_state.remove_data_for_paths(
+            deleted_paths,
+            clear_disk_caches=False,
+        )
+        if resolved_marks:
+            self.app_state.set_deletion_marks(
+                dict.fromkeys(resolved_marks, False)
+            )
+        for path in deleted_paths:
+            self.image_pipeline.invalidate_path(path)
+        if deleted_paths:
+            self.thumbnail_loader.invalidate_paths(deleted_paths)
+            self._remove_model_paths_batch(deleted_paths)
+            self.proxy_model.invalidate()
+            self.grouping_step_widget.remove_deleted_paths(deleted_paths)
             if (
                 self.easy_delete_step_widget is not None
                 and self.app_state.easy_delete_results is not None
@@ -4844,25 +4836,157 @@ class MainWindow(QMainWindow):
             self.mark_cull_model_dirty()
             self._refresh_workflow_deletion_state()
 
-        logger.info(f"Completed committing {deleted_count} deletions")
-        return len(resolved_marks) == len(marked_files)
+        completion = context["completion"]
+        completion(
+            successful_targets,
+            deleted_paths,
+            failures,
+            resolved_marks,
+        )
+
+    def _remove_model_paths_batch(self, deleted_paths: list[str]) -> None:
+        """Remove matching source rows with one model traversal."""
+
+        targets = set(deleted_paths)
+        if not targets:
+            return
+        root = self.file_system_model.invisibleRootItem()
+        queue = [root]
+        rows_by_parent: dict[int, tuple[QStandardItem, list[int]]] = {}
+        parent_candidates: list[QStandardItem] = []
+        while queue:
+            parent = queue.pop()
+            for row in range(parent.rowCount()):
+                child = parent.child(row)
+                if child is None:
+                    continue
+                data = child.data(Qt.ItemDataRole.UserRole)
+                path = data.get("path") if isinstance(data, dict) else None
+                if path in targets:
+                    entry = rows_by_parent.setdefault(id(parent), (parent, []))
+                    entry[1].append(row)
+                    if parent not in parent_candidates:
+                        parent_candidates.append(parent)
+                elif child.hasChildren():
+                    queue.append(child)
+        for parent, rows in rows_by_parent.values():
+            for row in sorted(rows, reverse=True):
+                parent.takeRow(row)
+        for path in targets:
+            normalized = os.path.normpath(path)
+            self._file_items_by_path.pop(normalized, None)
+            self._thumbnail_icons_by_path.pop(normalized, None)
+        self.file_deletion_controller._prune_empty_parent_groups(parent_candidates)
+
+    def _finish_marked_deletion_batch(
+        self,
+        visible_paths_before: list[str],
+        current_selected_path_before: str | None,
+        marked_files: list[str],
+        successful_targets: list[str],
+        deleted_paths: list[str],
+        failures: dict[str, str],
+        resolved_marks: set[str],
+    ) -> None:
+        active_view = self._get_active_file_view()
+        if deleted_paths and active_view:
+            visible_after = self._get_all_visible_image_paths()
+            anchor_path = (
+                current_selected_path_before
+                if current_selected_path_before in deleted_paths
+                else deleted_paths[0]
+            )
+            next_path = select_next_surviving_path(
+                visible_paths_before,
+                deleted_paths,
+                anchor_path,
+                visible_after,
+            )
+            if next_path:
+                next_index = self._find_proxy_index_for_path(next_path)
+                if next_index.isValid():
+                    active_view.setCurrentIndex(next_index)
+                    active_view.selectionModel().select(
+                        next_index,
+                        QItemSelectionModel.SelectionFlag.ClearAndSelect,
+                    )
+                    active_view.scrollTo(
+                        next_index,
+                        QAbstractItemView.ScrollHint.EnsureVisible,
+                    )
+                    QTimer.singleShot(0, self._handle_file_selection_changed)
+            elif not visible_after:
+                self.advanced_image_viewer.clear()
+                self.advanced_image_viewer.setText("No images left to display.")
+            self._update_image_info_label()
+
+        if failures:
+            self.statusBar().showMessage(
+                f"Moved {len(successful_targets)} item(s) to Trash; "
+                f"{len(failures)} failed.",
+                5000,
+            )
+        else:
+            self.statusBar().showMessage(
+                f"Committed {len(successful_targets)} deletion(s).", 5000
+            )
+
+        all_resolved = len(resolved_marks) == len(set(marked_files))
+        resume_folder_load = getattr(
+            self.app_controller, "resume_folder_load_after_deletion", None
+        )
+        if callable(resume_folder_load):
+            resume_folder_load(all_resolved)
+        if self._close_after_deletion:
+            self._close_after_deletion = False
+            if all_resolved:
+                self._finish_close_after_deletion()
+            else:
+                self.statusBar().showMessage(
+                    "Some items could not be moved to Trash. Close was cancelled.",
+                    5000,
+                )
+        request = self._pending_workflow_transition
+        if request is not None and request.trash_resolution == "commit":
+            self._pending_workflow_transition = None
+            if not all_resolved:
+                self.statusBar().showMessage(
+                    "Some marked files could not be moved to Trash. "
+                    "Resolve them before switching.",
+                    5000,
+                )
+                return
+            self._reset_deletion_workflow_decisions()
+            if request.destination is not None:
+                self._show_workflow_destination(request.destination)
+            else:
+                self.update_workflow_navigation()
+
+    def _finish_close_after_deletion(self) -> None:
+        """Close only after the deletion worker thread has fully shut down."""
+        if getattr(
+            self.worker_manager, "is_file_deletion_running", lambda: False
+        )():
+            QTimer.singleShot(25, self._finish_close_after_deletion)
+            return
+        self.close()
 
     def _commit_marked_deletions_without_confirmation(self):
         """Finds all marked files and moves them to trash without confirmation, updating the view in-place."""
         active_view = self._get_active_file_view()
         if not self.app_state.current_folder_path or not active_view:
             self.statusBar().showMessage("No folder loaded.", 3000)
-            return
+            return False
 
         marked_files = self.app_state.get_marked_files()
         if not marked_files:
             self.statusBar().showMessage("No images are marked for deletion.", 3000)
-            return
+            return False
 
         logger.info(
             f"Committing {len(marked_files)} marked deletions without confirmation"
         )
-        self._perform_deletion_of_marked_files(marked_files)
+        return self._perform_deletion_of_marked_files(marked_files)
 
     def _mark_selection_for_deletion(self):
         """Toggles the deletion mark for selected files, updating the model in-place."""
@@ -4909,22 +5033,19 @@ class MainWindow(QMainWindow):
         if not file_path:
             return
 
-        # Mark the file for deletion in the app state
-        is_marked = self._is_marked_for_deletion(file_path)
-        if is_marked:
-            self.app_state.unmark_for_deletion(file_path)
-        else:
-            self.app_state.mark_for_deletion(file_path)
-
-        # Update the UI
-        self.deletion_controller.toggle_paths(
+        changed = self.deletion_controller.mark_paths(
             [file_path],
             self._find_proxy_index_for_path,
             self.file_system_model,
             self.proxy_model,
         )
 
-        self.statusBar().showMessage("Marked 1 image for deletion.", 5000)
+        self.statusBar().showMessage(
+            "Marked 1 image for deletion."
+            if changed
+            else "Image is already marked for deletion.",
+            5000,
+        )
         self.proxy_model.invalidate()
 
     def _mark_others_for_deletion(self, file_path_to_keep: str):
@@ -4969,10 +5090,7 @@ class MainWindow(QMainWindow):
             self.statusBar().showMessage("Image is not marked for deletion.", 3000)
             return
 
-        # Unmark the file for deletion in the app state
-        self.app_state.unmark_for_deletion(file_path)
-
-        self.deletion_controller.toggle_paths(
+        self.deletion_controller.unmark_paths(
             [file_path],
             self._find_proxy_index_for_path,
             self.file_system_model,
@@ -5029,6 +5147,7 @@ class MainWindow(QMainWindow):
             self.statusBar().showMessage("No images are marked for deletion.", 3000)
             return
 
+        preserved_selection = self._get_selected_file_paths_from_view()
         self.deletion_controller.clear_all_and_update(
             self._find_proxy_index_for_path,
             self.file_system_model,
@@ -5040,54 +5159,10 @@ class MainWindow(QMainWindow):
         )
         self.proxy_model.invalidate()
         self._refresh_workflow_deletion_state()
-
-        visible_paths = self._get_all_visible_image_paths()
-        if not visible_paths:
-            self.advanced_image_viewer.clear()
-            return
-
-        first_path = marked_files[0]
-        first_proxy_idx = self._find_proxy_index_for_path(first_path)
-        if first_proxy_idx.isValid():
-            active_view = self._get_active_file_view()
-            if active_view:
-                active_view.setCurrentIndex(first_proxy_idx)
-                active_view.selectionModel().select(
-                    first_proxy_idx, QItemSelectionModel.SelectionFlag.ClearAndSelect
-                )
-                active_view.scrollTo(
-                    first_proxy_idx, QAbstractItemView.ScrollHint.EnsureVisible
-                )
-
-        final_selection_paths = list(marked_files)
-        self._handle_file_selection_changed(
-            override_selected_paths=final_selection_paths
-        )
-
-        if first_path:
-            self.advanced_image_viewer.set_focused_viewer_by_path(first_path)
-
-        selection = QItemSelection()
-        first_idx = QModelIndex()
-        for path in final_selection_paths:
-            proxy_idx = self._find_proxy_index_for_path(path)
-            if proxy_idx.isValid():
-                selection.select(proxy_idx, proxy_idx)
-                if not first_idx.isValid():
-                    first_idx = proxy_idx
-
-        if not selection.isEmpty():
-            active_view = self._get_active_file_view()
-            if active_view:
-                active_view.selectionModel().blockSignals(True)
-                active_view.selectionModel().select(
-                    selection, QItemSelectionModel.SelectionFlag.ClearAndSelect
-                )
-                active_view.selectionModel().blockSignals(False)
-                if first_idx.isValid():
-                    active_view.scrollTo(
-                        first_idx, QAbstractItemView.ScrollHint.EnsureVisible
-                    )
+        if preserved_selection:
+            self._handle_file_selection_changed(
+                override_selected_paths=preserved_selection
+            )
 
     def _get_current_selected_image_path(self) -> str | None:
         """Get the file path of the currently selected image."""
@@ -5110,11 +5185,7 @@ class MainWindow(QMainWindow):
         if not isinstance(item_data, dict) or "path" not in item_data:
             return None
 
-        file_path = item_data["path"]
-        if not os.path.exists(file_path):
-            return None
-
-        return file_path
+        return item_data["path"]
 
     def _handle_focused_image_changed(self, index: int, file_path: str):
         """Slot to handle when the focused image changes in the viewer."""

--- a/src/ui/menu_manager.py
+++ b/src/ui/menu_manager.py
@@ -870,9 +870,7 @@ class MenuManager:
         try:
             normalized_path = os.path.normpath(file_path)
             if os.name == "nt":
-                QProcess.startDetached(
-                    "explorer", ["/select,", normalized_path]
-                )
+                QProcess.startDetached("explorer", ["/select,", normalized_path])
             elif os.name == "posix":
                 if os.uname().sysname == "Darwin":
                     QProcess.startDetached("open", ["-R", normalized_path])

--- a/src/ui/menu_manager.py
+++ b/src/ui/menu_manager.py
@@ -1,9 +1,8 @@
 import logging
 import os
-import subprocess
 from typing import TYPE_CHECKING
 
-from PyQt6.QtCore import QPoint, Qt, QSignalBlocker
+from PyQt6.QtCore import QPoint, QProcess, Qt, QSignalBlocker
 from PyQt6.QtGui import QAction, QActionGroup, QIcon, QKeySequence
 from PyQt6.QtWidgets import QMenu, QStyle
 
@@ -871,13 +870,15 @@ class MenuManager:
         try:
             normalized_path = os.path.normpath(file_path)
             if os.name == "nt":
-                subprocess.run(["explorer", "/select,", normalized_path], check=False)
+                QProcess.startDetached(
+                    "explorer", ["/select,", normalized_path]
+                )
             elif os.name == "posix":
                 if os.uname().sysname == "Darwin":
-                    subprocess.run(["open", "-R", normalized_path], check=False)
+                    QProcess.startDetached("open", ["-R", normalized_path])
                 else:
-                    subprocess.run(
-                        ["xdg-open", os.path.dirname(normalized_path)], check=False
+                    QProcess.startDetached(
+                        "xdg-open", [os.path.dirname(normalized_path)]
                     )
         except Exception as e:
             logger.error(

--- a/src/ui/metadata_sidebar.py
+++ b/src/ui/metadata_sidebar.py
@@ -23,6 +23,7 @@ from PyQt6.QtGui import QFont
 
 from core.media_utils import is_video_extension
 from core.utils.time_utils import format_duration
+
 logger = logging.getLogger(__name__)
 
 
@@ -820,9 +821,7 @@ class MetadataSidebar(QWidget):
 
                 try:
                     creation_times = []
-                    for i, _path in enumerate(
-                        self.current_image_paths_for_comparison
-                    ):
+                    for i, _path in enumerate(self.current_image_paths_for_comparison):
                         creation_date = None
 
                         # Try to get creation date from EXIF data first

--- a/src/ui/metadata_sidebar.py
+++ b/src/ui/metadata_sidebar.py
@@ -5,6 +5,7 @@ Displays comprehensive image metadata in a modern, elegant sidebar
 
 import os
 import logging
+import contextlib
 from datetime import datetime
 from typing import Any
 from PyQt6.QtWidgets import (
@@ -22,8 +23,6 @@ from PyQt6.QtGui import QFont
 
 from core.media_utils import is_video_extension
 from core.utils.time_utils import format_duration
-import contextlib
-
 logger = logging.getLogger(__name__)
 
 
@@ -354,7 +353,10 @@ class MetadataSidebar(QWidget):
         """Update the sidebar with new metadata, resetting to single-image view."""
         self.comparison_mode = False
         self.current_image_path = image_path
-        self.raw_metadata = raw_exif or {}
+        # Scanner and metadata-worker results are already in memory. Keep one
+        # merged payload so rendering never needs filesystem fallbacks.
+        self.raw_metadata = dict(metadata or {})
+        self.raw_metadata.update(raw_exif or {})
         if is_video_extension(image_path):
             self.title_label.setText("Video Details")
         else:
@@ -450,11 +452,6 @@ class MetadataSidebar(QWidget):
             if value is not None:
                 with contextlib.suppress(ValueError, TypeError):
                     size_in_bytes = int(value)
-            if size_in_bytes is None and path and os.path.exists(path):
-                try:
-                    size_in_bytes = os.stat(path).st_size
-                except FileNotFoundError:
-                    return "N/A"
             if size_in_bytes is not None:
                 return (
                     f"{size_in_bytes / (1024 * 1024):.2f} MB"
@@ -576,6 +573,33 @@ class MetadataSidebar(QWidget):
             return str(value)
         except ValueError, TypeError:
             return str(value)
+
+    @staticmethod
+    def _cached_creation_datetime(metadata: dict[str, Any]) -> datetime | None:
+        """Resolve creation time from worker-populated metadata only."""
+
+        cached_date = metadata.get("date")
+        if isinstance(cached_date, datetime):
+            return cached_date
+        if cached_date is not None and hasattr(cached_date, "timetuple"):
+            try:
+                return datetime.combine(cached_date, datetime.min.time())
+            except TypeError:
+                pass
+
+        mtime_ns = metadata.get("mtime_ns")
+        if mtime_ns is not None:
+            try:
+                return datetime.fromtimestamp(float(mtime_ns) / 1_000_000_000)
+            except ValueError, TypeError, OSError:
+                pass
+        mtime = metadata.get("mtime")
+        if mtime is not None:
+            try:
+                return datetime.fromtimestamp(float(mtime))
+            except ValueError, TypeError, OSError:
+                pass
+        return None
 
     def add_comparison_cards(self):
         """
@@ -796,7 +820,9 @@ class MetadataSidebar(QWidget):
 
                 try:
                     creation_times = []
-                    for i, p in enumerate(self.current_image_paths_for_comparison):
+                    for i, _path in enumerate(
+                        self.current_image_paths_for_comparison
+                    ):
                         creation_date = None
 
                         # Try to get creation date from EXIF data first
@@ -827,16 +853,15 @@ class MetadataSidebar(QWidget):
 
                         # Fallback to filesystem creation/birth time
                         if creation_date is None:
-                            stat = os.stat(p)
-                            # Use birth time if available, otherwise modified time
-                            if hasattr(stat, "st_birthtime") and stat.st_birthtime > 0:
-                                creation_date = datetime.fromtimestamp(
-                                    stat.st_birthtime
-                                )
-                            else:
-                                creation_date = datetime.fromtimestamp(stat.st_mtime)
+                            creation_date = self._cached_creation_datetime(
+                                self.raw_metadata_for_comparison[i]
+                            )
 
-                        creation_times.append(creation_date.strftime("%Y-%m-%d %H:%M"))
+                        creation_times.append(
+                            creation_date.strftime("%Y-%m-%d %H:%M")
+                            if creation_date is not None
+                            else "N/A"
+                        )
 
                     card.add_comparison_row("Created", creation_times)
                     rows_added += 1
@@ -940,23 +965,17 @@ class MetadataSidebar(QWidget):
         """Add file information card"""
         card = MetadataCard("File Information", "FI")
 
-        if os.path.exists(self.current_image_path):
+        if self.current_image_path:
             # File name
             card.add_info_row("Name", os.path.basename(self.current_image_path))
 
-            # File size - prefer from metadata if available
-            file_size = self.raw_metadata.get("FileSize")
-            if file_size and file_size != "Unknown":
-                card.add_info_row("Size", str(file_size))
-            else:
-                # Fallback to filesystem size
-                stat = os.stat(self.current_image_path)
-                size_mb = stat.st_size / (1024 * 1024)
-                if size_mb < 1:
-                    size_str = f"{stat.st_size / 1024:.1f} KB"
-                else:
-                    size_str = f"{size_mb:.2f} MB"
-                card.add_info_row("Size", size_str)
+            file_size = self.raw_metadata.get(
+                "FileSize", self.raw_metadata.get("file_size")
+            )
+            card.add_info_row(
+                "Size",
+                self._format_display_value(file_size, "size_fallback"),
+            )
 
             # Creation date (from EXIF data or filesystem)
             creation_date = None
@@ -981,14 +1000,9 @@ class MetadataSidebar(QWidget):
                     except ValueError, TypeError, AttributeError:
                         continue
 
-            # Fallback to filesystem creation/birth time
+            # Scanner/metadata-worker fallback
             if creation_date is None:
-                stat = os.stat(self.current_image_path)
-                # Use birth time if available, otherwise modified time
-                if hasattr(stat, "st_birthtime") and stat.st_birthtime > 0:
-                    creation_date = datetime.fromtimestamp(stat.st_birthtime)
-                else:
-                    creation_date = datetime.fromtimestamp(stat.st_mtime)
+                creation_date = self._cached_creation_datetime(self.raw_metadata)
 
             if creation_date:
                 card.add_info_row("Created", creation_date.strftime("%B %d, %Y %H:%M"))

--- a/src/ui/pick_best_step_widget.py
+++ b/src/ui/pick_best_step_widget.py
@@ -1111,9 +1111,7 @@ class PickBestStepWidget(QWidget):
     def _build_metadata_rows(self, path: str) -> list[tuple[str, str]]:
         app_state = getattr(self.window(), "app_state", None)
         cache = (
-            getattr(app_state, "detailed_metadata_cache", None)
-            if app_state
-            else None
+            getattr(app_state, "detailed_metadata_cache", None) if app_state else None
         )
         try:
             rows = build_workflow_metadata_rows(path, cache)

--- a/src/ui/pick_best_step_widget.py
+++ b/src/ui/pick_best_step_widget.py
@@ -1110,7 +1110,11 @@ class PickBestStepWidget(QWidget):
 
     def _build_metadata_rows(self, path: str) -> list[tuple[str, str]]:
         app_state = getattr(self.window(), "app_state", None)
-        cache = getattr(app_state, "exif_disk_cache", None) if app_state else None
+        cache = (
+            getattr(app_state, "detailed_metadata_cache", None)
+            if app_state
+            else None
+        )
         try:
             rows = build_workflow_metadata_rows(path, cache)
         except Exception:

--- a/src/ui/ui_components.py
+++ b/src/ui/ui_components.py
@@ -637,17 +637,13 @@ class SimilarityWorker(QObject):
             self.error.emit(str(e))
             self.finished.emit()
 
-    def _handle_clustering_complete(
-        self, cluster_results: dict[str, int]
-    ) -> None:
+    def _handle_clustering_complete(self, cluster_results: dict[str, int]) -> None:
         """Apply and persist analysis-cache state before returning to the UI."""
 
         results = dict(cluster_results or {})
         if self.analysis_cache is not None and self.folder_path:
             try:
-                overrides = self.analysis_cache.get_manual_overrides(
-                    self.folder_path
-                )
+                overrides = self.analysis_cache.get_manual_overrides(self.folder_path)
                 for path, cluster_id in overrides.items():
                     if path in results:
                         results[path] = cluster_id

--- a/src/ui/ui_components.py
+++ b/src/ui/ui_components.py
@@ -571,6 +571,8 @@ class SimilarityWorker(QObject):
         file_paths: list[str],
         allow_model_download: bool = False,
         image_pipeline: ImagePipeline | None = None,
+        folder_path: str | None = None,
+        analysis_cache=None,
         parent=None,
     ):
         super().__init__(parent)
@@ -579,6 +581,8 @@ class SimilarityWorker(QObject):
         self._is_running = True
         self.similarity_engine = None
         self.image_pipeline = image_pipeline
+        self.folder_path = folder_path
+        self.analysis_cache = analysis_cache
 
     def _has_raw_images(self) -> bool:
         """Check if any of the file paths are RAW image files."""
@@ -615,11 +619,12 @@ class SimilarityWorker(QObject):
             self.similarity_engine.regional_embeddings_generated.connect(
                 self.regional_embeddings_generated
             )
-            self.similarity_engine.clustering_complete.connect(self.clustering_complete)
+            self.similarity_engine.clustering_complete.connect(
+                self._handle_clustering_complete
+            )
             self.similarity_engine.error.connect(self.error)
 
-            # 3. Connect the final signal to this worker's finished signal
-            self.similarity_engine.clustering_complete.connect(self.finished)
+            # 3. Connect the final error signal to this worker's finished signal
             self.similarity_engine.error.connect(self.finished)
 
             # 4. Start the process
@@ -631,6 +636,29 @@ class SimilarityWorker(QObject):
             )
             self.error.emit(str(e))
             self.finished.emit()
+
+    def _handle_clustering_complete(
+        self, cluster_results: dict[str, int]
+    ) -> None:
+        """Apply and persist analysis-cache state before returning to the UI."""
+
+        results = dict(cluster_results or {})
+        if self.analysis_cache is not None and self.folder_path:
+            try:
+                overrides = self.analysis_cache.get_manual_overrides(
+                    self.folder_path
+                )
+                for path, cluster_id in overrides.items():
+                    if path in results:
+                        results[path] = cluster_id
+                self.analysis_cache.save_cluster_results(
+                    self.folder_path,
+                    results,
+                )
+            except Exception:
+                logger.exception("Failed to persist similarity results.")
+        self.clustering_complete.emit(results)
+        self.finished.emit()
 
 
 # --- CUDA Detection Worker ---

--- a/src/ui/worker_manager.py
+++ b/src/ui/worker_manager.py
@@ -775,9 +775,7 @@ class WorkerManager(QObject):
         self.file_deletion_worker.completed.connect(self.file_deletion_complete)
         self.file_deletion_worker.finished.connect(self.file_deletion_thread.quit)
         self.file_deletion_thread.started.connect(self.file_deletion_worker.run)
-        self.file_deletion_thread.finished.connect(
-            self._cleanup_file_deletion_refs
-        )
+        self.file_deletion_thread.finished.connect(self._cleanup_file_deletion_refs)
         self.file_deletion_thread.start()
         logger.info("File deletion thread started for %d target(s).", len(targets))
         return True

--- a/src/ui/worker_manager.py
+++ b/src/ui/worker_manager.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from workers.ai_rating_worker import AiRatingWorker
     from workers.best_shot_worker import BestShotWorker
     from workers.easy_delete_worker import EasyDeleteWorker
+    from workers.file_deletion_worker import FileDeletionWorker
     from workers.grouping_worker import GroupingPreviewWorker, GroupingWorkflowWorker
     from workers.pick_best_worker import PickBestWorker
     from workers.rating_loader_worker import RatingLoaderWorker
@@ -136,6 +137,10 @@ class WorkerManager(QObject):
     grouping_workflow_complete = pyqtSignal(object)
     grouping_workflow_error = pyqtSignal(str)
 
+    # Filesystem deletion signals
+    file_deletion_progress = pyqtSignal(int, int, str)
+    file_deletion_complete = pyqtSignal(object)
+
     # Pick Best signals
     pick_best_progress = pyqtSignal(int, str)
     pick_best_complete = pyqtSignal(dict)
@@ -193,6 +198,8 @@ class WorkerManager(QObject):
         self.grouping_preview_worker: GroupingPreviewWorker | None = None
         self.grouping_workflow_thread: QThread | None = None
         self.grouping_workflow_worker: GroupingWorkflowWorker | None = None
+        self.file_deletion_thread: QThread | None = None
+        self.file_deletion_worker: FileDeletionWorker | None = None
 
         self.pick_best_thread: QThread | None = None
         self.pick_best_worker: PickBestWorker | None = None
@@ -375,7 +382,12 @@ class WorkerManager(QObject):
 
     # --- Similarity Engine Management ---
     def start_similarity_analysis(
-        self, file_paths: list[str], allow_model_download: bool = False
+        self,
+        file_paths: list[str],
+        allow_model_download: bool = False,
+        *,
+        folder_path: str | None = None,
+        analysis_cache=None,
     ):
         from ui.ui_components import SimilarityWorker
 
@@ -386,6 +398,8 @@ class WorkerManager(QObject):
             file_paths,
             allow_model_download=allow_model_download,
             image_pipeline=self.image_pipeline,
+            folder_path=folder_path,
+            analysis_cache=analysis_cache,
         )
         self.similarity_worker.moveToThread(self.similarity_thread)
 
@@ -678,6 +692,9 @@ class WorkerManager(QObject):
         prepared_plan=None,
         location_depth: int = 3,
         move_companions: bool = False,
+        rating_cache=None,
+        exif_cache=None,
+        analysis_cache=None,
     ):
         from workers.grouping_worker import GroupingWorkflowWorker
 
@@ -693,6 +710,9 @@ class WorkerManager(QObject):
             location_depth=location_depth,
             move_companions=move_companions,
             image_pipeline=self.image_pipeline,
+            rating_cache=rating_cache,
+            exif_cache=exif_cache,
+            analysis_cache=analysis_cache,
         )
         self.grouping_workflow_worker.moveToThread(self.grouping_workflow_thread)
 
@@ -718,6 +738,64 @@ class WorkerManager(QObject):
             allow_terminate=False,
         )
 
+    def _cleanup_file_deletion_refs(self) -> None:
+        self._cleanup_worker_refs(
+            "file_deletion_thread",
+            "file_deletion_worker",
+            "File deletion",
+        )
+
+    def start_file_deletion(
+        self,
+        targets: list[str],
+        *,
+        cache_paths_by_target: dict[str, list[str]] | None = None,
+        rating_cache=None,
+        exif_cache=None,
+        analysis_cache=None,
+        folder_path: str | None = None,
+    ) -> bool:
+        """Start one serialized Trash batch without blocking the UI thread."""
+
+        from workers.file_deletion_worker import FileDeletionWorker
+
+        if self.is_file_deletion_running() or not targets:
+            return False
+        self.file_deletion_thread = QThread()
+        self.file_deletion_worker = FileDeletionWorker(
+            targets,
+            cache_paths_by_target=cache_paths_by_target,
+            rating_cache=rating_cache,
+            exif_cache=exif_cache,
+            analysis_cache=analysis_cache,
+            folder_path=folder_path,
+        )
+        self.file_deletion_worker.moveToThread(self.file_deletion_thread)
+        self.file_deletion_worker.progress.connect(self.file_deletion_progress)
+        self.file_deletion_worker.completed.connect(self.file_deletion_complete)
+        self.file_deletion_worker.finished.connect(self.file_deletion_thread.quit)
+        self.file_deletion_thread.started.connect(self.file_deletion_worker.run)
+        self.file_deletion_thread.finished.connect(
+            self._cleanup_file_deletion_refs
+        )
+        self.file_deletion_thread.start()
+        logger.info("File deletion thread started for %d target(s).", len(targets))
+        return True
+
+    def stop_file_deletion(self) -> None:
+        # Never terminate a thread while the platform Trash API owns a file.
+        self._stop_worker(
+            "file_deletion_thread",
+            "file_deletion_worker",
+            allow_terminate=False,
+        )
+
+    def is_file_deletion_running(self) -> bool:
+        return (
+            self.file_deletion_thread is not None
+            and self.file_deletion_thread.isRunning()
+        )
+
     def stop_all_workers(self):
         logger.info("Stopping all workers...")
         self.stop_file_scan()
@@ -735,6 +813,7 @@ class WorkerManager(QObject):
         self.stop_ai_rating()
         self.stop_grouping_preview()
         self.stop_grouping_workflow()
+        self.stop_file_deletion()
         self.stop_pick_best_analysis()
         self.stop_easy_delete_analysis()
         self.stop_fix_rotation_detection()
@@ -853,6 +932,7 @@ class WorkerManager(QObject):
             or self.is_preview_warming_running()
             or self.is_grouping_preview_running()
             or self.is_grouping_workflow_running()
+            or self.is_file_deletion_running()
             or self.is_best_shot_worker_running()
             or self.is_ai_rating_running()
             or self.is_pick_best_running()

--- a/src/ui/workflow_metadata.py
+++ b/src/ui/workflow_metadata.py
@@ -69,9 +69,7 @@ def build_workflow_metadata_rows(
     if isinstance(exif_disk_cache, Mapping):
         metadata = exif_disk_cache.get(os.path.normpath(path))
     else:
-        metadata = MetadataProcessor.get_cached_detailed_metadata(
-            path, exif_disk_cache
-        )
+        metadata = MetadataProcessor.get_cached_detailed_metadata(path, exif_disk_cache)
     rows: list[tuple[str, str]] = []
 
     if isinstance(metadata, dict):

--- a/src/ui/workflow_metadata.py
+++ b/src/ui/workflow_metadata.py
@@ -1,4 +1,6 @@
 from fractions import Fraction
+import os
+from collections.abc import Mapping
 
 from core.metadata_processor import (
     DATE_TAGS_PREFERENCE,
@@ -63,8 +65,13 @@ def _format_capture_date(metadata: dict) -> str | None:
 def build_workflow_metadata_rows(
     path: str, exif_disk_cache, *, limit: int = 6
 ) -> list[tuple[str, str]]:
-    """Format cached EXIF data for workflow decision cards without file I/O."""
-    metadata = MetadataProcessor.get_cached_detailed_metadata(path, exif_disk_cache)
+    """Format memory-cached EXIF data for workflow decision cards."""
+    if isinstance(exif_disk_cache, Mapping):
+        metadata = exif_disk_cache.get(os.path.normpath(path))
+    else:
+        metadata = MetadataProcessor.get_cached_detailed_metadata(
+            path, exif_disk_cache
+        )
     rows: list[tuple[str, str]] = []
 
     if isinstance(metadata, dict):

--- a/src/ui/workflow_transition.py
+++ b/src/ui/workflow_transition.py
@@ -11,6 +11,7 @@ class WorkflowPendingState:
     rotation_count: int = 0
     rotation_changes: dict[str, int] = field(default_factory=dict)
     trash_paths: list[str] = field(default_factory=list)
+    directory_paths: set[str] = field(default_factory=set)
 
     @property
     def has_resolvable_work(self) -> bool:

--- a/src/workers/best_shot_worker.py
+++ b/src/workers/best_shot_worker.py
@@ -297,15 +297,6 @@ class BestShotWorker(QObject):
                 entry.get("batch_rank", 0),
             )
         )
-        if self._analysis_cache and self._folder_path:
-            try:
-                self._analysis_cache.update_best_shot_results(
-                    self._folder_path, cluster_id, final_results
-                )
-            except Exception:
-                logger.exception(
-                    "Failed to persist best-shot results for cluster %s", cluster_id
-                )
         return final_results
 
     def _analyze_cluster(
@@ -327,16 +318,6 @@ class BestShotWorker(QObject):
                     "analysis": "",
                 }
             ]
-            if self._analysis_cache and self._folder_path:
-                try:
-                    self._analysis_cache.update_best_shot_results(
-                        self._folder_path, cluster_id, single_results
-                    )
-                except Exception:
-                    logger.exception(
-                        "Failed to persist single-image best-shot result for cluster %s",
-                        cluster_id,
-                    )
             return single_results
         rankings = self._rank_cluster_with_batching(cluster_id, normalized_paths)
         return rankings
@@ -438,6 +419,16 @@ class BestShotWorker(QObject):
                 self._shutdown_executor(cancel=self._should_stop)
 
             if not self._should_stop:
+                if self._analysis_cache and self._folder_path:
+                    try:
+                        self._analysis_cache.update_best_shot_results_batch(
+                            self._folder_path,
+                            results,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Failed to persist best-shot result batch."
+                        )
                 total_results = sum(len(results) for results in results.values())
                 logger.info(
                     f"Best shot analysis completed: {total_results} results from {len(results)} clusters"

--- a/src/workers/best_shot_worker.py
+++ b/src/workers/best_shot_worker.py
@@ -426,9 +426,7 @@ class BestShotWorker(QObject):
                             results,
                         )
                     except Exception:
-                        logger.exception(
-                            "Failed to persist best-shot result batch."
-                        )
+                        logger.exception("Failed to persist best-shot result batch.")
                 total_results = sum(len(results) for results in results.values())
                 logger.info(
                     f"Best shot analysis completed: {total_results} results from {len(results)} clusters"

--- a/src/workers/file_deletion_worker.py
+++ b/src/workers/file_deletion_worker.py
@@ -1,0 +1,113 @@
+import logging
+import os
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+
+from PyQt6.QtCore import QObject, pyqtSignal
+
+from core.caching.path_cache_ops import delete_cached_paths
+from core.image_file_ops import ImageFileOperations
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class FileDeletionResult:
+    successful_targets: list[str] = field(default_factory=list)
+    failures: dict[str, str] = field(default_factory=dict)
+
+
+class FileDeletionWorker(QObject):
+    """Move a deletion batch to Trash and invalidate its disk-cache keys."""
+
+    progress = pyqtSignal(int, int, str)
+    completed = pyqtSignal(object)
+    finished = pyqtSignal()
+
+    def __init__(
+        self,
+        targets: Iterable[str],
+        *,
+        cache_paths_by_target: dict[str, list[str]] | None = None,
+        rating_cache=None,
+        exif_cache=None,
+        analysis_cache=None,
+        folder_path: str | None = None,
+        trash_operation: Callable[[str], tuple[bool, str]] | None = None,
+    ) -> None:
+        super().__init__()
+        self.targets = list(dict.fromkeys(path for path in targets if path))
+        self.cache_paths_by_target = {
+            path: list(dict.fromkeys(paths))
+            for path, paths in (cache_paths_by_target or {}).items()
+        }
+        self.rating_cache = rating_cache
+        self.exif_cache = exif_cache
+        self.analysis_cache = analysis_cache
+        self.folder_path = folder_path
+        self.trash_operation = (
+            trash_operation or ImageFileOperations.move_to_trash
+        )
+        self._should_stop = False
+
+    def stop(self) -> None:
+        self._should_stop = True
+
+    def run(self) -> None:
+        result = FileDeletionResult()
+        total = len(self.targets)
+        deleted_cache_paths: set[str] = set()
+        try:
+            for current, target in enumerate(self.targets, start=1):
+                if self._should_stop:
+                    result.failures.update(
+                        {
+                            pending: "Deletion cancelled."
+                            for pending in self.targets[current - 1 :]
+                        }
+                    )
+                    break
+                self.progress.emit(current, total, os.path.basename(target) or target)
+                try:
+                    success, message = self.trash_operation(target)
+                except Exception as exc:
+                    success, message = False, str(exc)
+                if not success:
+                    result.failures[target] = message or "Could not move to Trash."
+                    continue
+                result.successful_targets.append(target)
+                deleted_cache_paths.update(
+                    self.cache_paths_by_target.get(target, [target])
+                )
+                try:
+                    delete_cached_paths(
+                        self.cache_paths_by_target.get(target, [target]),
+                        rating_cache=self.rating_cache,
+                        exif_cache=self.exif_cache,
+                    )
+                except Exception:
+                    # The file mutation succeeded, so cache cleanup must never
+                    # turn it into a reported deletion failure.
+                    logger.warning(
+                        "Failed to invalidate disk caches after trashing %s",
+                        target,
+                        exc_info=True,
+                    )
+            if (
+                deleted_cache_paths
+                and self.analysis_cache is not None
+                and self.folder_path
+            ):
+                try:
+                    self.analysis_cache.remove_paths(
+                        self.folder_path,
+                        deleted_cache_paths,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to invalidate analysis cache after deletion.",
+                        exc_info=True,
+                    )
+            self.completed.emit(result)
+        finally:
+            self.finished.emit()

--- a/src/workers/file_deletion_worker.py
+++ b/src/workers/file_deletion_worker.py
@@ -45,9 +45,7 @@ class FileDeletionWorker(QObject):
         self.exif_cache = exif_cache
         self.analysis_cache = analysis_cache
         self.folder_path = folder_path
-        self.trash_operation = (
-            trash_operation or ImageFileOperations.move_to_trash
-        )
+        self.trash_operation = trash_operation or ImageFileOperations.move_to_trash
         self._should_stop = False
 
     def stop(self) -> None:

--- a/src/workers/grouping_worker.py
+++ b/src/workers/grouping_worker.py
@@ -11,6 +11,7 @@ from core.grouping import (
     execute_grouping_plan,
 )
 from core.image_pipeline import ImagePipeline
+from core.caching.path_cache_ops import migrate_cached_paths
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,9 @@ class GroupingWorkflowWorker(QObject):
         location_depth: int = 3,
         move_companions: bool = False,
         image_pipeline: ImagePipeline | None = None,
+        rating_cache=None,
+        exif_cache=None,
+        analysis_cache=None,
         parent=None,
     ):
         super().__init__(parent)
@@ -98,6 +102,9 @@ class GroupingWorkflowWorker(QObject):
         self.location_depth = location_depth
         self.move_companions = move_companions
         self.image_pipeline = image_pipeline
+        self.rating_cache = rating_cache
+        self.exif_cache = exif_cache
+        self.analysis_cache = analysis_cache
         self._should_stop = False
 
     def stop(self):
@@ -135,6 +142,22 @@ class GroupingWorkflowWorker(QObject):
                 progress_callback=self.progress_update.emit,
                 move_companions=self.move_companions,
             )
+            path_updates = {
+                entry.original_path: entry.new_path
+                for entry in summary.entries
+                if entry.new_path
+            }
+            migrate_cached_paths(
+                path_updates,
+                rating_cache=self.rating_cache,
+                exif_cache=self.exif_cache,
+            )
+            if self.analysis_cache is not None:
+                self.analysis_cache.migrate_folder_paths(
+                    self.source_root,
+                    self.output_root,
+                    path_updates,
+                )
             if self._should_stop:
                 return
             self.progress_update.emit(100, "Grouping complete.")

--- a/src/workers/rating_loader_worker.py
+++ b/src/workers/rating_loader_worker.py
@@ -24,6 +24,7 @@ class MetadataState(Protocol):
     exif_disk_cache: Any
     rating_cache: dict[str, int]
     date_cache: dict[str, Any]
+    detailed_metadata_cache: dict[str, dict[str, Any]]
 
 
 class RatingLoaderWorker(QObject):
@@ -123,6 +124,12 @@ class RatingLoaderWorker(QObject):
 
             metadata_batch_to_emit = []
             emitted_batch_count = 0
+            detailed_metadata_cache = getattr(
+                self._app_state, "detailed_metadata_cache", None
+            )
+            if not isinstance(detailed_metadata_cache, dict):
+                detailed_metadata_cache = {}
+                self._app_state.detailed_metadata_cache = detailed_metadata_cache
 
             for i, image_path_norm in enumerate(image_paths_to_process):
                 if not self._is_running:
@@ -143,6 +150,11 @@ class RatingLoaderWorker(QObject):
                         self._app_state.date_cache[image_path_norm] = metadata["date"]
                     else:
                         self._app_state.date_cache.pop(image_path_norm, None)
+                    raw_metadata = metadata.get("raw_metadata")
+                    if isinstance(raw_metadata, dict):
+                        detailed_metadata_cache[image_path_norm] = raw_metadata
+                    else:
+                        detailed_metadata_cache.pop(image_path_norm, None)
                     current_metadata_tuple = (image_path_norm, metadata)
                 else:
                     logger.warning(

--- a/tests/test_analysis_cache.py
+++ b/tests/test_analysis_cache.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import MagicMock, Mock
 
 from src.core.caching.analysis_cache import AnalysisCache
 
@@ -36,3 +37,89 @@ def test_analysis_cache_persists_clusters_and_best_shots(tmp_path):
     assert completed == {1}
 
     cache.close()
+
+
+def test_best_shot_batch_uses_one_cache_read_and_write():
+    cache = AnalysisCache.__new__(AnalysisCache)
+    cache._cache = MagicMock()
+    cache.load = Mock(return_value={})
+
+    cache.update_best_shot_results_batch(
+        "/photos",
+        {
+            1: [{"image_path": "a.jpg", "composite_score": 0.9}],
+            2: [{"image_path": "b.jpg", "composite_score": 0.8}],
+        },
+    )
+
+    cache.load.assert_called_once_with("/photos")
+    cache._cache.set.assert_called_once()
+    saved = cache._cache.set.call_args.args[1]
+    assert set(saved["best_shot_rankings"]) == {"1", "2"}
+
+
+def test_analysis_cache_migrates_folder_and_all_path_references():
+    old = "/photos/source/a.jpg"
+    new = "/photos/output/a.jpg"
+    cache = AnalysisCache.__new__(AnalysisCache)
+    cache._cache = MagicMock()
+    cache._cache.__contains__ = Mock(return_value=True)
+    cache.load = Mock(
+        return_value={
+            "cluster_results": {old: 1},
+            "manual_cluster_overrides": {old: 2},
+            "best_shot_rankings": {"1": [{"image_path": old}]},
+            "best_shot_scores_by_path": {old: {"image_path": old}},
+            "best_shot_winners": {"1": {"image_path": old}},
+        }
+    )
+
+    cache.migrate_folder_paths(
+        "/photos/source",
+        "/photos/output",
+        {old: new},
+    )
+
+    cache.load.assert_called_once_with("/photos/source")
+    cache._cache.set.assert_called_once()
+    saved = cache._cache.set.call_args.args[1]
+    assert saved["cluster_results"] == {new: 1}
+    assert saved["manual_cluster_overrides"] == {new: 2}
+    assert saved["best_shot_rankings"]["1"][0]["image_path"] == new
+    assert saved["best_shot_scores_by_path"][new]["image_path"] == new
+    assert saved["best_shot_winners"]["1"]["image_path"] == new
+    cache._cache.__delitem__.assert_called_once()
+
+
+def test_analysis_cache_removes_deleted_paths_with_one_read_and_write():
+    removed = "/photos/deleted.jpg"
+    kept = "/photos/kept.jpg"
+    cache = AnalysisCache.__new__(AnalysisCache)
+    cache._cache = MagicMock()
+    cache.load = Mock(
+        return_value={
+            "cluster_results": {removed: 1, kept: 1},
+            "manual_cluster_overrides": {removed: 1},
+            "best_shot_rankings": {
+                "1": [{"image_path": removed}, {"image_path": kept}]
+            },
+            "best_shot_scores_by_path": {
+                removed: {"image_path": removed},
+                kept: {"image_path": kept},
+            },
+            "best_shot_winners": {"1": {"image_path": removed}},
+        }
+    )
+
+    cache.remove_paths("/photos", {removed})
+
+    cache.load.assert_called_once_with("/photos")
+    cache._cache.set.assert_called_once()
+    saved = cache._cache.set.call_args.args[1]
+    assert saved["cluster_results"] == {kept: 1}
+    assert saved["manual_cluster_overrides"] == {}
+    assert saved["best_shot_rankings"] == {"1": [{"image_path": kept}]}
+    assert saved["best_shot_scores_by_path"] == {
+        kept: {"image_path": kept}
+    }
+    assert saved["best_shot_winners"] == {"1": {"image_path": kept}}

--- a/tests/test_analysis_cache.py
+++ b/tests/test_analysis_cache.py
@@ -119,7 +119,5 @@ def test_analysis_cache_removes_deleted_paths_with_one_read_and_write():
     assert saved["cluster_results"] == {kept: 1}
     assert saved["manual_cluster_overrides"] == {}
     assert saved["best_shot_rankings"] == {"1": [{"image_path": kept}]}
-    assert saved["best_shot_scores_by_path"] == {
-        kept: {"image_path": kept}
-    }
+    assert saved["best_shot_scores_by_path"] == {kept: {"image_path": kept}}
     assert saved["best_shot_winners"] == {"1": {"image_path": kept}}

--- a/tests/test_app_controller_similarity_model.py
+++ b/tests/test_app_controller_similarity_model.py
@@ -86,6 +86,8 @@ class _WorkerManager:
 
 class _AppState:
     image_files_data = [{"path": "/tmp/a.jpg", "media_type": "image"}]
+    current_folder_path = "/tmp"
+    analysis_cache = object()
 
 
 def test_similarity_declined_model_download_cancels_cleanly(monkeypatch):
@@ -129,7 +131,11 @@ def test_similarity_approved_model_download_starts_worker_with_download(monkeypa
 
     assert worker_manager.started is True
     assert worker_manager.paths == ["/tmp/a.jpg"]
-    assert worker_manager.kwargs == {"allow_model_download": True}
+    assert worker_manager.kwargs == {
+        "allow_model_download": True,
+        "folder_path": "/tmp",
+        "analysis_cache": _AppState.analysis_cache,
+    }
     assert main_window.shown == ["Starting similarity analysis..."]
 
 

--- a/tests/test_app_state_media_index.py
+++ b/tests/test_app_state_media_index.py
@@ -167,9 +167,7 @@ def test_batch_path_update_scans_shared_results_once_without_disk_io():
         "new-a.jpg",
         "new-b.jpg",
     ]
-    assert state.easy_delete_results == {
-        "new-a.jpg": {"pair_path": "new-b.jpg"}
-    }
+    assert state.easy_delete_results == {"new-a.jpg": {"pair_path": "new-b.jpg"}}
     cluster = state.pick_best_results[1]
     assert cluster["all_paths"] == ["new-a.jpg", "new-b.jpg"]
     assert cluster["ranked"] == [{"path": "new-a.jpg"}]

--- a/tests/test_app_state_media_index.py
+++ b/tests/test_app_state_media_index.py
@@ -145,6 +145,7 @@ def test_batch_path_update_scans_shared_results_once_without_disk_io():
     ]
     state.easy_delete_results = {
         "a.jpg": {"pair_path": "b.jpg"},
+        "unpaired.jpg": {"pair_path": None},
     }
     state.pick_best_results = {
         1: {
@@ -167,7 +168,10 @@ def test_batch_path_update_scans_shared_results_once_without_disk_io():
         "new-a.jpg",
         "new-b.jpg",
     ]
-    assert state.easy_delete_results == {"new-a.jpg": {"pair_path": "new-b.jpg"}}
+    assert state.easy_delete_results == {
+        "new-a.jpg": {"pair_path": "new-b.jpg"},
+        "unpaired.jpg": {"pair_path": None},
+    }
     cluster = state.pick_best_results[1]
     assert cluster["all_paths"] == ["new-a.jpg", "new-b.jpg"]
     assert cluster["ranked"] == [{"path": "new-a.jpg"}]

--- a/tests/test_app_state_media_index.py
+++ b/tests/test_app_state_media_index.py
@@ -101,3 +101,78 @@ def test_assignment_removal_and_rename_keep_index_consistent():
     assert state.pick_best_results == {}
     assert state.pick_best_winners_by_path == {}
     assert state.media_summary() == MediaSummary()
+
+
+def test_batch_removal_rebuilds_media_index_once_and_invalidates_results():
+    state = _state()
+    state.image_files_data = [
+        {"path": f"{index}.jpg", "media_type": "image", "file_size": index}
+        for index in range(10)
+    ]
+    state.easy_delete_results = {
+        "0.jpg": {"pair_path": "1.jpg"},
+        "keep.jpg": {"pair_path": "9.jpg"},
+    }
+    state.pick_best_results = {
+        1: {"all_paths": ["0.jpg", "1.jpg"], "winner_path": "0.jpg"},
+        2: {"all_paths": ["8.jpg", "9.jpg"], "winner_path": "8.jpg"},
+    }
+    state.pick_best_winners_by_path = {"0.jpg": True, "8.jpg": True}
+    with patch.object(
+        state, "_rebuild_media_index", wraps=state._rebuild_media_index
+    ) as rebuild:
+        removed = state.remove_data_for_paths(
+            ["0.jpg", "1.jpg"],
+            clear_disk_caches=False,
+        )
+
+    assert removed == 2
+    rebuild.assert_called_once_with()
+    assert state.get_file_data_by_path("0.jpg") is None
+    assert state.get_file_data_by_path("2.jpg") is not None
+    assert state.easy_delete_results == {"keep.jpg": {"pair_path": "9.jpg"}}
+    assert set(state.pick_best_results) == {2}
+    assert state.pick_best_winners_by_path == {"8.jpg": True}
+    state.rating_disk_cache.delete.assert_not_called()
+    state.exif_disk_cache.delete.assert_not_called()
+
+
+def test_batch_path_update_scans_shared_results_once_without_disk_io():
+    state = _state()
+    state.image_files_data = [
+        {"path": "a.jpg", "media_type": "image", "file_size": 1},
+        {"path": "b.jpg", "media_type": "image", "file_size": 2},
+    ]
+    state.easy_delete_results = {
+        "a.jpg": {"pair_path": "b.jpg"},
+    }
+    state.pick_best_results = {
+        1: {
+            "winner_path": "a.jpg",
+            "all_paths": ["a.jpg", "b.jpg"],
+            "unsupported_paths": ["b.jpg"],
+            "ranked": [{"path": "a.jpg"}],
+            "failed": [{"path": "b.jpg"}],
+            "_mark_state": {"a.jpg": True, "b.jpg": False},
+        }
+    }
+
+    updated = state.update_paths(
+        {"a.jpg": "new-a.jpg", "b.jpg": "new-b.jpg"},
+        migrate_disk_caches=False,
+    )
+
+    assert updated == 2
+    assert [item["path"] for item in state.image_files_data] == [
+        "new-a.jpg",
+        "new-b.jpg",
+    ]
+    assert state.easy_delete_results == {
+        "new-a.jpg": {"pair_path": "new-b.jpg"}
+    }
+    cluster = state.pick_best_results[1]
+    assert cluster["all_paths"] == ["new-a.jpg", "new-b.jpg"]
+    assert cluster["ranked"] == [{"path": "new-a.jpg"}]
+    assert cluster["failed"] == [{"path": "new-b.jpg"}]
+    state.rating_disk_cache.get.assert_not_called()
+    state.exif_disk_cache.get.assert_not_called()

--- a/tests/test_cluster_utils.py
+++ b/tests/test_cluster_utils.py
@@ -1,5 +1,4 @@
 import datetime
-import os
 from src.ui.helpers.cluster_utils import ClusterUtils
 
 
@@ -64,7 +63,7 @@ def test_sort_clusters_with_embeddings():
     assert len(order) == 2
 
 
-def test_cluster_timestamps_fallback_to_filesystem_time(tmp_path):
+def test_cluster_timestamps_use_scanner_mtime_without_filesystem_io(tmp_path):
     older = tmp_path / "older.jpg"
     newer = tmp_path / "newer.jpg"
     older.write_text("a")
@@ -72,13 +71,13 @@ def test_cluster_timestamps_fallback_to_filesystem_time(tmp_path):
 
     old_ts = 1_700_000_000
     new_ts = 1_800_000_000
-    os.utime(older, (old_ts, old_ts))
-    os.utime(newer, (new_ts, new_ts))
-
-    data = [build_fd(str(older)), build_fd(str(newer))]
+    data = [
+        {"path": str(older), "mtime_ns": old_ts * 1_000_000_000},
+        {"path": str(newer), "mtime_ns": new_ts * 1_000_000_000},
+    ]
     clusters = {str(older): 2, str(newer): 1}
     grouped = ClusterUtils.group_images_by_cluster(data, clusters)
 
-    # Empty cache should still resolve timestamps from filesystem metadata.
+    # Empty date cache falls back to scanner data, not one stat call per image.
     ts = ClusterUtils.get_cluster_timestamps(grouped, date_cache={})
     assert ts[2] < ts[1]

--- a/tests/test_deferred_folder_load.py
+++ b/tests/test_deferred_folder_load.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from ui.app_controller import AppController
+
+
+def test_folder_load_resume_waits_for_deletion_thread_shutdown(monkeypatch):
+    callbacks = []
+    worker_manager = SimpleNamespace(is_file_deletion_running=lambda: True)
+    controller = AppController(
+        SimpleNamespace(),
+        SimpleNamespace(),
+        worker_manager,
+    )
+    controller._pending_folder_load = (
+        "/next",
+        {
+            "skip_grouping_step": False,
+            "record_as_source": True,
+            "preserve_deletion_marks": False,
+        },
+    )
+    controller.load_folder = Mock()
+    monkeypatch.setattr(
+        "ui.app_controller.QTimer.singleShot",
+        lambda _delay, callback: callbacks.append(callback),
+    )
+
+    controller.resume_folder_load_after_deletion(True)
+
+    assert controller._pending_folder_load is not None
+    controller.load_folder.assert_not_called()
+    worker_manager.is_file_deletion_running = lambda: False
+    callbacks.pop()()
+    controller.load_folder.assert_called_once_with(
+        "/next",
+        skip_grouping_step=False,
+        record_as_source=True,
+        preserve_deletion_marks=False,
+    )

--- a/tests/test_deletion_mark_controller_batch.py
+++ b/tests/test_deletion_mark_controller_batch.py
@@ -1,0 +1,71 @@
+from PyQt6.QtCore import QSortFilterProxyModel, Qt
+from PyQt6.QtGui import QStandardItem, QStandardItemModel
+from PyQt6.QtWidgets import QApplication
+
+from ui.controllers.deletion_mark_controller import DeletionMarkController
+
+_app = QApplication.instance() or QApplication([])
+
+
+class _MarkState:
+    def __init__(self):
+        self.marked_for_deletion: set[str] = set()
+
+    def is_marked_for_deletion(self, path: str) -> bool:
+        return path in self.marked_for_deletion
+
+    def set_deletion_marks(self, state: dict[str, bool]) -> int:
+        changed = 0
+        for path, marked in state.items():
+            if marked != (path in self.marked_for_deletion):
+                changed += 1
+            if marked:
+                self.marked_for_deletion.add(path)
+            else:
+                self.marked_for_deletion.discard(path)
+        return changed
+
+    def get_marked_files(self):
+        return list(self.marked_for_deletion)
+
+
+def _model(paths: list[str]):
+    source = QStandardItemModel()
+    for path in paths:
+        item = QStandardItem(path)
+        item.setData({"path": path, "is_blurred": False}, Qt.ItemDataRole.UserRole)
+        source.appendRow(item)
+    proxy = QSortFilterProxyModel()
+    proxy.setSourceModel(source)
+    return source, proxy
+
+
+def test_toggle_and_clear_batches_never_call_per_path_lookup():
+    paths = [f"{index}.jpg" for index in range(100)]
+    state = _MarkState()
+    source, proxy = _model(paths)
+    controller = DeletionMarkController(state, state.is_marked_for_deletion)
+
+    def forbidden_lookup(_path):
+        raise AssertionError("bulk operations must not traverse once per path")
+
+    assert (
+        controller.toggle_paths(
+            paths[:75],
+            forbidden_lookup,
+            source,
+            proxy,
+        )
+        == 75
+    )
+    assert state.marked_for_deletion == set(paths[:75])
+
+    assert (
+        controller.clear_all_and_update(
+            forbidden_lookup,
+            source,
+            proxy,
+        )
+        == 75
+    )
+    assert state.marked_for_deletion == set()

--- a/tests/test_file_deletion_controller.py
+++ b/tests/test_file_deletion_controller.py
@@ -195,6 +195,33 @@ class DeletionTestContext:
                         )
         return QModelIndex()
 
+    def _start_deletion_batch(
+        self, targets, _represented_by_target, *, completion
+    ):
+        """Simulate the central background-deletion completion boundary."""
+
+        target_set = set(targets)
+        self.app_controller.moved_to_trash.extend(targets)
+        root = self.file_system_model.invisibleRootItem()
+
+        def remove_targets(parent):
+            for row in range(parent.rowCount() - 1, -1, -1):
+                child = parent.child(row)
+                if child is None:
+                    continue
+                data = child.data(Qt.ItemDataRole.UserRole)
+                if isinstance(data, dict) and data.get("path") in target_set:
+                    self.app_state.remove_data_for_path(data["path"])
+                    parent.takeRow(row)
+                    continue
+                remove_targets(child)
+                if isinstance(data, str) and child.rowCount() == 0:
+                    parent.takeRow(row)
+
+        remove_targets(root)
+        completion(list(targets), list(targets), {}, set())
+        return True
+
     def _handle_file_selection_changed(
         self, override_selected_paths=None
     ):  # pragma: no cover - trivial

--- a/tests/test_file_deletion_controller.py
+++ b/tests/test_file_deletion_controller.py
@@ -195,9 +195,7 @@ class DeletionTestContext:
                         )
         return QModelIndex()
 
-    def _start_deletion_batch(
-        self, targets, _represented_by_target, *, completion
-    ):
+    def _start_deletion_batch(self, targets, _represented_by_target, *, completion):
         """Simulate the central background-deletion completion boundary."""
 
         target_set = set(targets)

--- a/tests/test_file_deletion_worker.py
+++ b/tests/test_file_deletion_worker.py
@@ -1,0 +1,47 @@
+from unittest.mock import Mock
+
+from workers.file_deletion_worker import FileDeletionWorker
+
+
+def test_deletion_worker_invalidates_only_successful_targets():
+    trash = Mock(
+        side_effect=[
+            (True, "ok"),
+            (False, "busy"),
+        ]
+    )
+    rating_cache = Mock()
+    exif_cache = Mock()
+    analysis_cache = Mock()
+    results = []
+    worker = FileDeletionWorker(
+        ["folder", "failed.jpg"],
+        cache_paths_by_target={
+            "folder": ["folder/a.jpg", "folder/b.jpg"],
+            "failed.jpg": ["failed.jpg"],
+        },
+        rating_cache=rating_cache,
+        exif_cache=exif_cache,
+        analysis_cache=analysis_cache,
+        folder_path="/photos",
+        trash_operation=trash,
+    )
+    worker.completed.connect(results.append)
+
+    worker.run()
+
+    result = results[0]
+    assert result.successful_targets == ["folder"]
+    assert result.failures == {"failed.jpg": "busy"}
+    assert [call.args[0] for call in rating_cache.delete.call_args_list] == [
+        "folder/a.jpg",
+        "folder/b.jpg",
+    ]
+    assert [call.args[0] for call in exif_cache.delete.call_args_list] == [
+        "folder/a.jpg",
+        "folder/b.jpg",
+    ]
+    analysis_cache.remove_paths.assert_called_once_with(
+        "/photos",
+        {"folder/a.jpg", "folder/b.jpg"},
+    )

--- a/tests/test_find_proxy_index_for_path.py
+++ b/tests/test_find_proxy_index_for_path.py
@@ -1,4 +1,5 @@
 import os
+from types import SimpleNamespace
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QStandardItemModel, QStandardItem
 from PyQt6.QtWidgets import QApplication, QTreeView
@@ -102,3 +103,19 @@ def test_find_proxy_index_not_found(tmp_path):
     idx = mw._find_proxy_index_for_path(str(tmp_path / "missing.jpg"))
     assert not idx.isValid()
     assert not idx.isValid()
+
+
+def test_model_item_validation_never_stats_the_filesystem(monkeypatch):
+    model = QStandardItemModel()
+    proxy = QSortFilterProxyModel()
+    proxy.setSourceModel(model)
+    model.appendRow(make_item("/slow-volume/photo.jpg"))
+    index = proxy.index(0, 0)
+    monkeypatch.setattr(
+        "src.ui.main_window.os.path.isfile",
+        lambda _path: (_ for _ in ()).throw(AssertionError("unexpected stat")),
+    )
+
+    context = SimpleNamespace(proxy_model=proxy, file_system_model=model)
+
+    assert MainWindow._is_valid_image_item(context, index) is True

--- a/tests/test_grouping_step_widget.py
+++ b/tests/test_grouping_step_widget.py
@@ -128,14 +128,18 @@ def test_organize_tree_headers_expand_and_collapse_each_tree(tmp_path):
     assert widget.after_expand_all_button.isEnabled()
     assert widget.after_collapse_all_button.isEnabled()
     assert all(item.isExpanded() for item in _expandable_tree_items(widget.before_tree))
-    assert all(item.isExpanded() for item in _expandable_tree_items(widget.preview_tree))
+    assert all(
+        item.isExpanded() for item in _expandable_tree_items(widget.preview_tree)
+    )
 
     widget.before_collapse_all_button.click()
 
     assert not any(
         item.isExpanded() for item in _expandable_tree_items(widget.before_tree)
     )
-    assert all(item.isExpanded() for item in _expandable_tree_items(widget.preview_tree))
+    assert all(
+        item.isExpanded() for item in _expandable_tree_items(widget.preview_tree)
+    )
 
     widget.after_collapse_all_button.click()
     assert not any(
@@ -146,7 +150,9 @@ def test_organize_tree_headers_expand_and_collapse_each_tree(tmp_path):
     widget.after_expand_all_button.click()
 
     assert all(item.isExpanded() for item in _expandable_tree_items(widget.before_tree))
-    assert all(item.isExpanded() for item in _expandable_tree_items(widget.preview_tree))
+    assert all(
+        item.isExpanded() for item in _expandable_tree_items(widget.preview_tree)
+    )
 
 
 def test_organize_tree_branch_style_distinguishes_folder_states_from_leaves():
@@ -175,13 +181,9 @@ def test_organize_tree_branch_style_distinguishes_folder_states_from_leaves():
 
     enabled = QStyle.StateFlag.State_Enabled
     leaf_pixels = rendered_pixels(enabled)
-    collapsed_pixels = rendered_pixels(
-        enabled | QStyle.StateFlag.State_Children
-    )
+    collapsed_pixels = rendered_pixels(enabled | QStyle.StateFlag.State_Children)
     expanded_pixels = rendered_pixels(
-        enabled
-        | QStyle.StateFlag.State_Children
-        | QStyle.StateFlag.State_Open
+        enabled | QStyle.StateFlag.State_Children | QStyle.StateFlag.State_Open
     )
 
     assert leaf_pixels == set()
@@ -238,7 +240,9 @@ def test_large_organize_tree_expansion_is_batched_and_cancelled_on_refresh(
     while timer.isActive():
         widget._process_tree_expansion_batch(widget.preview_tree)
 
-    assert all(item.isExpanded() for item in _expandable_tree_items(widget.preview_tree))
+    assert all(
+        item.isExpanded() for item in _expandable_tree_items(widget.preview_tree)
+    )
 
 
 def test_grouping_step_widget_detects_unsaved_grouping_edits(tmp_path):
@@ -1238,9 +1242,7 @@ def test_grouping_folder_preview_discards_thumbnail_updates_from_prior_folder():
     model.refresh_thumbnail_paths({old_path})
 
     assert changed_ranges == []
-    assert (
-        model.data(model.index(0, 0), Qt.ItemDataRole.UserRole) == current_path
-    )
+    assert model.data(model.index(0, 0), Qt.ItemDataRole.UserRole) == current_path
 
 
 def test_grouping_folder_preview_requests_thumbnail_loading(tmp_path):

--- a/tests/test_grouping_step_widget.py
+++ b/tests/test_grouping_step_widget.py
@@ -4,12 +4,15 @@ from unittest.mock import Mock
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
-from PyQt6.QtGui import QIcon, QPixmap
-from PyQt6.QtWidgets import QApplication, QMenu
+from PyQt6.QtCore import QRect, Qt
+from PyQt6.QtGui import QIcon, QPainter, QPixmap
+from PyQt6.QtWidgets import QApplication, QListView, QMenu, QStyle, QStyleOption
 
+import src.ui.grouping_step_widget as grouping_step_widget_module
 from src.core.grouping import GroupingGroup, GroupingPlan
 from src.ui.grouping_step_widget import (
     DroppableGroupingTree,
+    GroupingTreeBranchStyle,
     GroupingStepWidget,
     ITEM_GROUP,
     ROLE_KIND,
@@ -17,6 +20,19 @@ from src.ui.grouping_step_widget import (
 
 
 _app = QApplication.instance() or QApplication([])
+
+
+def _expandable_tree_items(tree):
+    stack = [
+        tree.topLevelItem(index)
+        for index in range(tree.topLevelItemCount() - 1, -1, -1)
+    ]
+    while stack:
+        item = stack.pop()
+        children = [item.child(index) for index in range(item.childCount())]
+        stack.extend(reversed(children))
+        if children:
+            yield item
 
 
 class _CacheOnlyPipeline:
@@ -78,6 +94,151 @@ def test_grouping_step_widget_tracks_mode_and_busy_state():
     assert widget.folder_button.isEnabled()
     assert widget.back_button.isEnabled()
     assert all(btn.isEnabled() for btn in widget._mode_buttons.values())
+
+
+def test_organize_tree_headers_expand_and_collapse_each_tree(tmp_path):
+    source_root = tmp_path / "demo"
+    nested = source_root / "Parent" / "Child"
+    nested.mkdir(parents=True)
+    first = str(nested / "a.jpg")
+    nested.joinpath("a.jpg").write_bytes(b"preview")
+
+    widget = GroupingStepWidget()
+    widget.set_source_folder(str(source_root))
+    widget.set_preview_plan(
+        GroupingPlan(
+            mode="current",
+            total_items=1,
+            supported_items=1,
+            groups=[
+                GroupingGroup(
+                    group_id="1",
+                    group_label="Parent/Child",
+                    source_paths=[first],
+                )
+            ],
+            unassigned_paths=[],
+            skipped_paths=[],
+        ),
+        str(source_root),
+    )
+
+    assert widget.before_expand_all_button.isEnabled()
+    assert widget.before_collapse_all_button.isEnabled()
+    assert widget.after_expand_all_button.isEnabled()
+    assert widget.after_collapse_all_button.isEnabled()
+    assert all(item.isExpanded() for item in _expandable_tree_items(widget.before_tree))
+    assert all(item.isExpanded() for item in _expandable_tree_items(widget.preview_tree))
+
+    widget.before_collapse_all_button.click()
+
+    assert not any(
+        item.isExpanded() for item in _expandable_tree_items(widget.before_tree)
+    )
+    assert all(item.isExpanded() for item in _expandable_tree_items(widget.preview_tree))
+
+    widget.after_collapse_all_button.click()
+    assert not any(
+        item.isExpanded() for item in _expandable_tree_items(widget.preview_tree)
+    )
+
+    widget.before_expand_all_button.click()
+    widget.after_expand_all_button.click()
+
+    assert all(item.isExpanded() for item in _expandable_tree_items(widget.before_tree))
+    assert all(item.isExpanded() for item in _expandable_tree_items(widget.preview_tree))
+
+
+def test_organize_tree_branch_style_distinguishes_folder_states_from_leaves():
+    style = GroupingTreeBranchStyle()
+
+    def rendered_pixels(state: QStyle.StateFlag) -> set[tuple[int, int]]:
+        pixmap = QPixmap(20, 20)
+        pixmap.fill(Qt.GlobalColor.transparent)
+        option = QStyleOption()
+        option.rect = QRect(0, 0, 20, 20)
+        option.state = state
+        painter = QPainter(pixmap)
+        style.drawPrimitive(
+            QStyle.PrimitiveElement.PE_IndicatorBranch,
+            option,
+            painter,
+        )
+        painter.end()
+        image = pixmap.toImage()
+        return {
+            (x, y)
+            for y in range(image.height())
+            for x in range(image.width())
+            if image.pixelColor(x, y).alpha() > 0
+        }
+
+    enabled = QStyle.StateFlag.State_Enabled
+    leaf_pixels = rendered_pixels(enabled)
+    collapsed_pixels = rendered_pixels(
+        enabled | QStyle.StateFlag.State_Children
+    )
+    expanded_pixels = rendered_pixels(
+        enabled
+        | QStyle.StateFlag.State_Children
+        | QStyle.StateFlag.State_Open
+    )
+
+    assert leaf_pixels == set()
+    assert collapsed_pixels
+    assert expanded_pixels
+    assert collapsed_pixels != expanded_pixels
+
+
+def test_large_organize_tree_expansion_is_batched_and_cancelled_on_refresh(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(grouping_step_widget_module, "LARGE_FOLDER_THRESHOLD", 1)
+    monkeypatch.setattr(grouping_step_widget_module, "UI_POPULATION_CHUNK_SIZE", 1)
+    source_root = tmp_path / "demo"
+    nested = source_root / "Parent" / "Child"
+    nested.mkdir(parents=True)
+    first = str(nested / "a.jpg")
+    second = str(nested / "b.jpg")
+    nested.joinpath("a.jpg").write_bytes(b"preview")
+    nested.joinpath("b.jpg").write_bytes(b"preview")
+
+    widget = GroupingStepWidget()
+    widget.set_source_folder(str(source_root))
+    widget.set_preview_plan(
+        GroupingPlan(
+            mode="current",
+            total_items=2,
+            supported_items=2,
+            groups=[
+                GroupingGroup(
+                    group_id="1",
+                    group_label="Parent/Child",
+                    source_paths=[first, second],
+                )
+            ],
+            unassigned_paths=[],
+            skipped_paths=[],
+        ),
+        str(source_root),
+    )
+
+    widget.after_expand_all_button.click()
+
+    timer = widget._tree_expansion_timers[widget.preview_tree]
+    assert timer.isActive()
+    assert widget.preview_tree in widget._tree_expansion_stacks
+
+    widget._refresh_preview_trees()
+
+    assert not timer.isActive()
+    assert widget.preview_tree not in widget._tree_expansion_stacks
+
+    widget.after_expand_all_button.click()
+    while timer.isActive():
+        widget._process_tree_expansion_batch(widget.preview_tree)
+
+    assert all(item.isExpanded() for item in _expandable_tree_items(widget.preview_tree))
 
 
 def test_grouping_step_widget_detects_unsaved_grouping_edits(tmp_path):
@@ -429,7 +590,10 @@ def test_grouping_step_widget_folder_preview_uses_cached_thumbnails_only(tmp_pat
     pipeline.get_cached_thumbnail_qpixmap.reset_mock()
     widget._update_folder_preview(widget._after_group_items_by_id["1"])
 
-    assert widget.folder_preview_grid.count() == 2
+    model = widget._folder_preview_model
+    assert model.rowCount() == 2
+    for row in range(model.rowCount()):
+        model.data(model.index(row, 0), Qt.ItemDataRole.DecorationRole)
     assert pipeline.get_thumbnail_qpixmap.call_count == 0
     assert pipeline.get_preview_qpixmap.call_count == 0
     assert pipeline.get_cached_thumbnail_qpixmap.call_count == 2
@@ -1010,9 +1174,73 @@ def test_grouping_step_widget_shows_folder_preview_grid(tmp_path):
     widget._handle_before_item_changed(before_dir, None)
 
     assert widget.preview_pane_stack.currentWidget() is widget.folder_preview_page
-    assert widget.folder_preview_grid.count() == 2
+    assert widget._folder_preview_model.rowCount() == 2
     assert widget.folder_preview_title.text() == "Beach"
     assert widget.visible_thumbnail_paths()[:2] == [first, second]
+
+
+def test_grouping_folder_preview_exposes_every_item_with_batched_layout(tmp_path):
+    source_root = tmp_path / "demo"
+    source_root.mkdir()
+    paths = [str(source_root / "Beach" / f"{index:04}.jpg") for index in range(275)]
+
+    widget = GroupingStepWidget()
+    widget.set_source_folder(str(source_root))
+    widget.set_preview_plan(
+        GroupingPlan(
+            mode="location",
+            total_items=len(paths),
+            supported_items=len(paths),
+            groups=[
+                GroupingGroup(
+                    group_id="1",
+                    group_label="Beach",
+                    source_paths=paths,
+                )
+            ],
+            unassigned_paths=[],
+            skipped_paths=[],
+            filesystem_inventory_complete=True,
+            source_root=str(source_root),
+            filesystem_paths=set(paths),
+            filesystem_directories={str(source_root / "Beach")},
+        ),
+        str(source_root),
+    )
+
+    widget._update_folder_preview(widget._after_group_items_by_id["1"])
+
+    model = widget._folder_preview_model
+    assert model.rowCount() == len(paths)
+    assert (
+        model.data(model.index(len(paths) - 1, 0), Qt.ItemDataRole.UserRole)
+        == paths[-1]
+    )
+    assert widget.folder_preview_meta.text().startswith(f"{len(paths)} item(s)\n")
+    assert "showing first" not in widget.folder_preview_meta.text()
+    assert widget.folder_preview_grid.layoutMode() == QListView.LayoutMode.Batched
+    assert widget.folder_preview_grid.batchSize() > 0
+
+
+def test_grouping_folder_preview_discards_thumbnail_updates_from_prior_folder():
+    widget = GroupingStepWidget()
+    model = widget._folder_preview_model
+    old_path = "/photos/old/a.jpg"
+    current_path = "/photos/current/b.jpg"
+    changed_ranges: list[tuple[int, int]] = []
+    model.dataChanged.connect(
+        lambda start, end, _roles: changed_ranges.append((start.row(), end.row()))
+    )
+
+    model.set_paths([old_path])
+    model.set_paths([current_path])
+    changed_ranges.clear()
+    model.refresh_thumbnail_paths({old_path})
+
+    assert changed_ranges == []
+    assert (
+        model.data(model.index(0, 0), Qt.ItemDataRole.UserRole) == current_path
+    )
 
 
 def test_grouping_folder_preview_requests_thumbnail_loading(tmp_path):
@@ -1111,9 +1339,10 @@ def test_grouping_step_widget_folder_preview_includes_unmanaged_files(tmp_path):
     before_dir = widget._before_dir_items_by_relative_path["Beach"]
     widget._handle_before_item_changed(before_dir, None)
 
+    model = widget._folder_preview_model
     names = {
-        widget.folder_preview_grid.item(index).text()
-        for index in range(widget.folder_preview_grid.count())
+        model.data(model.index(index, 0), Qt.ItemDataRole.DisplayRole)
+        for index in range(model.rowCount())
     }
 
     assert names == {"a.jpg", "a.json"}
@@ -1405,7 +1634,7 @@ def test_grouping_step_widget_keeps_folder_preview_visible_after_rename(tmp_path
 
     assert widget.preview_tree.currentItem() is widget._after_group_items_by_id["1"]
     assert widget.preview_pane_stack.currentWidget() is widget.folder_preview_page
-    assert widget.folder_preview_grid.count() == 1
+    assert widget._folder_preview_model.rowCount() == 1
 
 
 def test_grouping_step_widget_restores_selected_file_when_current_item_is_lost(
@@ -1794,3 +2023,93 @@ def test_grouping_step_widget_keyboard_navigation_skips_deleted(tmp_path):
     handled_override = widget.eventFilter(widget.preview_tree, event_down_override)
     assert handled_override is True
     assert widget.preview_tree.currentItem() is second_item
+
+
+def test_organize_left_arrow_moves_to_parent_then_collapses_folder(tmp_path):
+    from PyQt6.QtCore import QEvent
+    from PyQt6.QtGui import QKeyEvent
+
+    source_root = tmp_path / "demo"
+    source_root.mkdir()
+    first = str(source_root / "Parent" / "Child" / "a.jpg")
+    widget = GroupingStepWidget()
+    widget.set_source_folder(str(source_root))
+    widget.set_preview_plan(
+        GroupingPlan(
+            mode="location",
+            total_items=1,
+            supported_items=1,
+            groups=[
+                GroupingGroup(
+                    group_id="1",
+                    group_label="Parent/Child",
+                    source_paths=[first],
+                )
+            ],
+            unassigned_paths=[],
+            skipped_paths=[],
+        ),
+        str(source_root),
+    )
+    left = QKeyEvent(
+        QEvent.Type.KeyPress,
+        Qt.Key.Key_Left,
+        Qt.KeyboardModifier.NoModifier,
+    )
+
+    for tree, file_item in (
+        (widget.before_tree, widget._before_file_items_by_path[first]),
+        (widget.preview_tree, widget._after_file_items_by_path[first]),
+    ):
+        folder_item = file_item.parent()
+        assert folder_item is not None
+        assert folder_item.isExpanded()
+        tree.setCurrentItem(file_item)
+
+        assert widget.eventFilter(tree, left) is True
+        assert tree.currentItem() is folder_item
+        assert folder_item.isExpanded()
+
+        assert widget.eventFilter(tree, left) is True
+        assert tree.currentItem() is folder_item
+        assert not folder_item.isExpanded()
+
+
+def test_organize_left_arrow_keeps_collapsed_root_selected(tmp_path):
+    from PyQt6.QtCore import QEvent
+    from PyQt6.QtGui import QKeyEvent
+
+    source_root = tmp_path / "demo"
+    source_root.mkdir()
+    first = str(source_root / "a.jpg")
+    widget = GroupingStepWidget()
+    widget.set_source_folder(str(source_root))
+    widget.set_preview_plan(
+        GroupingPlan(
+            mode="current",
+            total_items=1,
+            supported_items=1,
+            groups=[
+                GroupingGroup(
+                    group_id="1",
+                    group_label="Root files",
+                    source_paths=[first],
+                )
+            ],
+            unassigned_paths=[],
+            skipped_paths=[],
+        ),
+        str(source_root),
+    )
+    root_item = widget.preview_tree.topLevelItem(0)
+    root_item.setExpanded(False)
+    widget.preview_tree.setCurrentItem(root_item)
+    left = QKeyEvent(
+        QEvent.Type.KeyPress,
+        Qt.Key.Key_Left,
+        Qt.KeyboardModifier.NoModifier,
+    )
+
+    assert widget.eventFilter(widget.preview_tree, left) is True
+    assert widget.preview_tree.currentItem() is root_item
+    assert not root_item.isExpanded()

--- a/tests/test_grouping_worker_cache_migration.py
+++ b/tests/test_grouping_worker_cache_migration.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from workers.grouping_worker import GroupingWorkflowWorker
+
+
+def test_grouping_worker_migrates_disk_cache_paths_before_completion(monkeypatch):
+    plan = SimpleNamespace(
+        apply_group_label_overrides=Mock(),
+        output_root="",
+    )
+    summary = SimpleNamespace(
+        entries=[
+            SimpleNamespace(original_path="/source/a.jpg", new_path="/output/a.jpg"),
+            SimpleNamespace(original_path="/source/b.jpg", new_path=None),
+        ]
+    )
+    migration = Mock()
+    monkeypatch.setattr(
+        "workers.grouping_worker.augment_grouping_plan_with_filesystem_paths",
+        lambda prepared, _root: prepared,
+    )
+    monkeypatch.setattr(
+        "workers.grouping_worker.execute_grouping_plan",
+        lambda *_args, **_kwargs: summary,
+    )
+    monkeypatch.setattr(
+        "workers.grouping_worker.migrate_cached_paths",
+        migration,
+    )
+
+    rating_cache = object()
+    exif_cache = object()
+    analysis_cache = Mock()
+    worker = GroupingWorkflowWorker(
+        items=[],
+        mode="current",
+        source_root="/source",
+        output_root="/output",
+        prepared_plan=plan,
+        rating_cache=rating_cache,
+        exif_cache=exif_cache,
+        analysis_cache=analysis_cache,
+    )
+    completed = Mock()
+    worker.completed.connect(completed)
+
+    worker.run()
+
+    migration.assert_called_once_with(
+        {"/source/a.jpg": "/output/a.jpg"},
+        rating_cache=rating_cache,
+        exif_cache=exif_cache,
+    )
+    completed.assert_called_once_with(summary)
+    analysis_cache.migrate_folder_paths.assert_called_once_with(
+        "/source",
+        "/output",
+        {"/source/a.jpg": "/output/a.jpg"},
+    )

--- a/tests/test_metadata_sidebar_cache_only.py
+++ b/tests/test_metadata_sidebar_cache_only.py
@@ -1,0 +1,36 @@
+import os
+from types import SimpleNamespace
+
+from PyQt6.QtWidgets import QApplication
+
+import ui.metadata_sidebar as metadata_sidebar_module
+from ui.metadata_sidebar import MetadataSidebar
+
+
+app = QApplication.instance() or QApplication([])
+
+
+def test_sidebar_rendering_uses_cached_file_data_without_stat(monkeypatch):
+    def unexpected_stat(_path):
+        raise AssertionError("metadata rendering must not stat selected files")
+
+    monkeypatch.setattr(
+        metadata_sidebar_module,
+        "os",
+        SimpleNamespace(path=os.path, stat=unexpected_stat),
+    )
+    sidebar = MetadataSidebar()
+    sidebar.update_metadata(
+        "/slow-volume/photo.jpg",
+        {
+            "file_size": 2048,
+            "mtime_ns": 1_700_000_000_000_000_000,
+            "rating": 3,
+        },
+        {"Exif.Image.Model": "Camera"},
+    )
+
+    sidebar._delayed_update()
+
+    assert sidebar.raw_metadata["file_size"] == 2048
+    assert sidebar.raw_metadata["Exif.Image.Model"] == "Camera"

--- a/tests/test_organize_deletion_integration.py
+++ b/tests/test_organize_deletion_integration.py
@@ -7,46 +7,44 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 from ui.main_window import MainWindow
 
 
-def test_organize_immediate_trash_removes_only_successful_paths(tmp_path, monkeypatch):
+def test_organize_trash_delegates_to_background_batch(tmp_path):
     first = str(tmp_path / "first.jpg")
     second = str(tmp_path / "second.jpg")
     (tmp_path / "first.jpg").write_bytes(b"first")
     (tmp_path / "second.jpg").write_bytes(b"second")
 
-    removed: list[str] = []
-    invalidated: list[str] = []
-    grouping_removed: list[list[str]] = []
-    errors: list[tuple[str, str]] = []
+    started: dict[str, object] = {}
+
+    def start_batch(targets, represented_by_target, completion):
+        started.update(
+            targets=targets,
+            represented_by_target=represented_by_target,
+            completion=completion,
+        )
+        return True
+
+    finish = Mock()
     context = SimpleNamespace(
         dialog_manager=SimpleNamespace(
             show_confirm_delete_dialog=lambda _paths: True,
-            show_error_dialog=lambda title, message: errors.append((title, message)),
         ),
-        app_state=SimpleNamespace(remove_data_for_path=removed.append),
-        image_pipeline=SimpleNamespace(invalidate_path=invalidated.append),
-        thumbnail_loader=SimpleNamespace(invalidate_paths=Mock()),
-        grouping_step_widget=SimpleNamespace(
-            remove_deleted_paths=grouping_removed.append
-        ),
-        proxy_model=SimpleNamespace(invalidate=Mock()),
-        mark_cull_model_dirty=Mock(),
-        _refresh_workflow_deletion_state=Mock(),
-        statusBar=lambda: SimpleNamespace(showMessage=Mock()),
-    )
-
-    def move_to_trash(path: str) -> tuple[bool, str]:
-        if path == first:
-            return True, "Moved to trash."
-        return False, "second.jpg could not be moved"
-
-    monkeypatch.setattr(
-        "ui.main_window.ImageFileOperations.move_to_trash", move_to_trash
+        grouping_step_widget=SimpleNamespace(known_directory_paths=lambda: set()),
+        _start_deletion_batch=start_batch,
+        _finish_ad_hoc_deletion=finish,
     )
 
     MainWindow._trash_from_organize(context, "", [first, second])
 
-    assert removed == [first]
-    assert invalidated == [first]
-    assert grouping_removed == [[first]]
-    context.thumbnail_loader.invalidate_paths.assert_called_once_with([first])
-    assert errors == [("Trash Error", "second.jpg could not be moved")]
+    assert started["targets"] == [first, second]
+    assert started["represented_by_target"] == {
+        first: [first],
+        second: [second],
+    }
+
+    started["completion"]([first], [first], {second: "failed"}, set())
+    finish.assert_called_once_with(
+        [first],
+        [first],
+        {second: "failed"},
+        operation_label="Trash",
+    )

--- a/tests/test_selection_controller.py
+++ b/tests/test_selection_controller.py
@@ -75,6 +75,24 @@ def test_selection_controller_returns_selected_paths(tmp_path):
     assert set(result) == {paths[0], paths[2]}
 
 
+def test_selection_controller_does_not_stat_selected_paths(monkeypatch):
+    QApplication.instance() or QApplication([])
+    path = "/slow-volume/image.jpg"
+    model = build_model_with_files([path])
+    ctx = DummyCtx(model)
+    controller = SelectionController(ctx)
+    ctx.get_active_view().selectionModel().select(
+        model.index(0, 0),
+        ctx.get_active_view().selectionModel().SelectionFlag.Select,
+    )
+    monkeypatch.setattr(
+        "os.path.isfile",
+        lambda _path: (_ for _ in ()).throw(AssertionError("unexpected stat")),
+    )
+
+    assert controller.get_selected_file_paths() == [path]
+
+
 def test_selection_controller_empty_when_no_view():
     QApplication.instance() or QApplication([])
     model = build_model_with_files([])

--- a/tests/test_statusbar_utils.py
+++ b/tests/test_statusbar_utils.py
@@ -28,7 +28,7 @@ def test_statusbar_with_cluster_and_blur_yes(tmp_path):
         width=100,
         height=200,
         cluster_lookup={str(f): 7},
-        file_data_from_model={"is_blurred": True},
+        file_data_from_model={"is_blurred": True, "file_size": 2048},
     )
     msg = info.to_message()
     assert "C: 7" in msg

--- a/tests/test_ui_yield.py
+++ b/tests/test_ui_yield.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from core.app_settings import LARGE_FOLDER_THRESHOLD, UI_POPULATION_CHUNK_SIZE
+import ui.helpers.ui_yield as ui_yield
+
+
+def test_cooperative_ui_yield_processes_large_collections_by_chunk(monkeypatch):
+    process_events = Mock()
+    monkeypatch.setattr(
+        ui_yield,
+        "QCoreApplication",
+        SimpleNamespace(instance=lambda: object(), processEvents=process_events),
+    )
+    progress = Mock()
+
+    ui_yield.cooperative_ui_yield(
+        UI_POPULATION_CHUNK_SIZE,
+        LARGE_FOLDER_THRESHOLD + 1,
+        progress_callback=progress,
+    )
+
+    progress.assert_called_once_with(
+        UI_POPULATION_CHUNK_SIZE,
+        LARGE_FOLDER_THRESHOLD + 1,
+    )
+    process_events.assert_called_once()
+
+
+def test_cooperative_ui_yield_skips_small_collections(monkeypatch):
+    process_events = Mock()
+    monkeypatch.setattr(
+        ui_yield,
+        "QCoreApplication",
+        SimpleNamespace(instance=lambda: object(), processEvents=process_events),
+    )
+
+    ui_yield.cooperative_ui_yield(1, LARGE_FOLDER_THRESHOLD)
+
+    process_events.assert_not_called()

--- a/tests/test_worker_manager_lifecycle.py
+++ b/tests/test_worker_manager_lifecycle.py
@@ -25,6 +25,7 @@ from ui.worker_manager import WorkerManager
         "ai_rating_thread",
         "grouping_preview_thread",
         "grouping_workflow_thread",
+        "file_deletion_thread",
         "pick_best_thread",
         "easy_delete_thread",
         "fix_rotation_detect_thread",

--- a/tests/test_workflow_transition_guard.py
+++ b/tests/test_workflow_transition_guard.py
@@ -18,6 +18,8 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+app = QApplication.instance() or QApplication([])
+
 
 class _ThumbnailSignals(QObject):
     thumbnail_session_batch_ready = pyqtSignal(str, object)
@@ -472,7 +474,7 @@ def test_rotation_dialog_shows_gallery_and_direct_switch_actions():
     review_cache.assert_called_once_with("/tmp/a.jpg")
 
 
-def test_deletion_preview_expands_folders_and_shows_non_media_files(tmp_path):
+def test_deletion_preview_keeps_folders_as_bounded_recursive_targets(tmp_path):
     folder = tmp_path / "Trip"
     nested = folder / "Metadata"
     nested.mkdir(parents=True)
@@ -488,6 +490,7 @@ def test_deletion_preview_expands_folders_and_shows_non_media_files(tmp_path):
         WorkflowPendingState(
             trash_paths=[str(folder)],
             organize_removed_folders=[str(empty_after_move)],
+            directory_paths={str(folder), str(empty_after_move)},
         )
     )
 
@@ -495,16 +498,27 @@ def test_deletion_preview_expands_folders_and_shows_non_media_files(tmp_path):
         path: (name, detail, is_directory)
         for path, name, detail, is_directory in entries
     }
-    assert set(by_path) == {
-        str(folder),
-        str(nested),
-        str(photo),
-        str(sidecar),
-        str(empty_after_move),
-    }
+    assert set(by_path) == {str(folder), str(empty_after_move)}
     assert by_path[str(folder)][2] is True
-    assert by_path[str(sidecar)][1] == "Inside Trip"
+    assert "all contents" in by_path[str(folder)][1]
     assert by_path[str(empty_after_move)][1] == "Empty folder removed after organizing"
+
+
+def test_deletion_preview_caps_widget_count_without_filesystem_walk(tmp_path):
+    targets = []
+    for index in range(DialogManager.MAX_TRANSITION_DELETION_PREVIEW_ITEMS + 25):
+        target = tmp_path / f"{index}.jpg"
+        target.write_bytes(b"x")
+        targets.append(str(target))
+
+    manager = DialogManager(QWidget())
+    entries = manager._build_deletion_preview_entries(
+        WorkflowPendingState(trash_paths=targets)
+    )
+
+    assert len(entries) == DialogManager.MAX_TRANSITION_DELETION_PREVIEW_ITEMS + 1
+    assert entries[-1][0] == ""
+    assert "25 more" in entries[-1][1]
 
 
 def test_organize_folder_mark_is_staged_and_unstaged_as_one_target(tmp_path):
@@ -514,16 +528,24 @@ def test_organize_folder_mark_is_staged_and_unstaged_as_one_target(tmp_path):
     photo.write_bytes(b"photo")
     marks: set[str] = set()
     app_state = SimpleNamespace(is_marked_for_deletion=marks.__contains__)
+
+    def set_paths_marked(mark_state, *_args):
+        for path, marked in mark_state.items():
+            if marked:
+                marks.add(path)
+            else:
+                marks.discard(path)
+
     deletion_controller = SimpleNamespace(
-        mark=marks.add,
-        unmark=marks.discard,
-        toggle_mark=lambda path: (
-            marks.discard(path) if path in marks else marks.add(path)
-        ),
+        set_paths_marked=set_paths_marked,
     )
     window = SimpleNamespace(
         app_state=app_state,
+        grouping_step_widget=SimpleNamespace(
+            known_directory_paths=lambda: {str(folder)}
+        ),
         deletion_controller=deletion_controller,
+        file_system_model=object(),
         proxy_model=SimpleNamespace(invalidate=Mock()),
         _refresh_visible_items_icons=Mock(),
         _refresh_workflow_deletion_state=Mock(),
@@ -536,3 +558,67 @@ def test_organize_folder_mark_is_staged_and_unstaged_as_one_target(tmp_path):
 
     MainWindow._toggle_organize_deletion_marks(window, targets)
     assert marks == set()
+
+
+def test_context_menu_mark_handler_sets_mark_without_toggling_back():
+    deletion_controller = SimpleNamespace(mark_paths=Mock(return_value=1))
+    status = SimpleNamespace(showMessage=Mock())
+    window = SimpleNamespace(
+        deletion_controller=deletion_controller,
+        _find_proxy_index_for_path=Mock(),
+        file_system_model=object(),
+        proxy_model=SimpleNamespace(invalidate=Mock()),
+        statusBar=lambda: status,
+    )
+
+    MainWindow._mark_image_for_deletion(window, "/tmp/photo.jpg")
+
+    deletion_controller.mark_paths.assert_called_once_with(
+        ["/tmp/photo.jpg"],
+        window._find_proxy_index_for_path,
+        window.file_system_model,
+        window.proxy_model,
+    )
+
+
+def test_context_menu_unmark_handler_sets_unmarked_without_toggling_back():
+    deletion_controller = SimpleNamespace(unmark_paths=Mock(return_value=1))
+    status = SimpleNamespace(showMessage=Mock())
+    window = SimpleNamespace(
+        deletion_controller=deletion_controller,
+        _is_marked_for_deletion=lambda _path: True,
+        _find_proxy_index_for_path=Mock(),
+        file_system_model=object(),
+        proxy_model=SimpleNamespace(invalidate=Mock()),
+        statusBar=lambda: status,
+    )
+
+    MainWindow._unmark_image_for_deletion(window, "/tmp/photo.jpg")
+
+    deletion_controller.unmark_paths.assert_called_once_with(
+        ["/tmp/photo.jpg"],
+        window._find_proxy_index_for_path,
+        window.file_system_model,
+        window.proxy_model,
+    )
+
+
+def test_deferred_close_waits_for_deletion_thread_shutdown(monkeypatch):
+    callbacks = []
+    worker_manager = SimpleNamespace(is_file_deletion_running=lambda: True)
+    window = SimpleNamespace(worker_manager=worker_manager, close=Mock())
+    window._finish_close_after_deletion = lambda: (
+        MainWindow._finish_close_after_deletion(window)
+    )
+    monkeypatch.setattr(
+        "ui.main_window.QTimer.singleShot",
+        lambda _delay, callback: callbacks.append(callback),
+    )
+
+    MainWindow._finish_close_after_deletion(window)
+
+    window.close.assert_not_called()
+    assert len(callbacks) == 1
+    worker_manager.is_file_deletion_running = lambda: False
+    callbacks.pop()()
+    window.close.assert_called_once_with()


### PR DESCRIPTION
Overall code cleanup to baches, this will greatly improve Photosort performance
Also updated organize window to be faster and easier to navigate

-- AI Overview:

## Summary

- batch AppState path removal and migration so deletion and Organize completion update shared caches and workflow results once
- move filesystem trash operations, cache invalidation, analysis persistence, and Organize cache migration off the UI thread
- replace repeated proxy-model searches with single-pass batch lookups for deletion marks and removals
- avoid synchronous filesystem metadata and directory-tree scans during selection, preview, status, workflow transitions, and pending-action previews
- virtualize the Organize folder preview so every item is available without the previous 200-item cap
- add responsive Expand all / Collapse all controls, visible folder disclosure indicators, and parent-then-collapse Left-arrow navigation
- fix the image context-menu Mark/Unmark handlers reversing their own state changes

## Why

Large deletion, marking, and Organize batches repeatedly rebuilt shared indexes, scanned complete models, touched disk caches, and mutated the filesystem on the UI thread. Several preview and transition paths also created unbounded Qt items or recursively walked directory trees before returning control to the event loop. Together these caused freezes that grew sharply with folder size.

## Impact

Bulk operations now use shared batch boundaries and background workers, large Qt populations yield or use virtualized/batched layout, and visible thumbnails continue through the existing shared image pipeline. Large folders should remain interactive during deletion, Organize completion, folder expansion, and folder preview browsing while preserving existing workflow behavior.