### PR TITLE
Refactor: Worker management and cancellation handling

### DIFF
--- a/src/core/file_scanner.py
+++ b/src/core/file_scanner.py
@@ -118,7 +118,9 @@ class FileScanner(QObject):
         perform_blur_detection: bool - If True, performs blur detection in parallel.
         blur_threshold: float - Threshold for blur detection if performed.
         """
-        self._is_running = True
+        if not self._is_running:
+            logger.info("File scan skipped because cancellation was already requested.")
+            return
         all_file_data: list[dict[str, Any]] = []
         discovery_batch: list[dict[str, Any]] = []
         image_paths_for_blur: list[str] = []

--- a/src/core/grouping.py
+++ b/src/core/grouping.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 
 import numpy as np
 from PIL import Image
@@ -33,6 +33,17 @@ class GroupingMode(StrEnum):
     FACE = "face"
     LOCATION = "location"
     MIXED = "mixed"
+
+
+class GroupingAnalysisCancelled(Exception):
+    """Raised when grouping preview analysis is cancelled."""
+
+
+def _raise_if_grouping_cancelled(
+    should_continue: Callable[[], bool] | None,
+) -> None:
+    if should_continue is not None and not should_continue():
+        raise GroupingAnalysisCancelled
 
 
 @dataclass(slots=True)
@@ -867,7 +878,9 @@ def _run_ml_similarity_pipeline(
     progress_callback=None,
     shared_engine: SimilarityEngine | None = None,
     image_pipeline: ImagePipeline | None = None,
+    should_continue: Callable[[], bool] | None = None,
 ) -> dict[str, int]:
+    _raise_if_grouping_cancelled(should_continue)
     if not image_paths:
         return {}
     if shared_engine is None:
@@ -880,6 +893,7 @@ def _run_ml_similarity_pipeline(
         list(image_paths),
         progress_callback=progress_callback,
     )
+    _raise_if_grouping_cancelled(should_continue)
     assignments: dict[str, int] = {}
     for path, raw_cluster in cluster_results.items():
         cluster_id = _parse_cluster_id(raw_cluster)
@@ -895,7 +909,10 @@ def build_grouping_plan(
     source_root: str | None = None,
     location_depth: int = 3,
     image_pipeline: ImagePipeline | None = None,
+    should_continue: Callable[[], bool] | None = None,
+    similarity_engine: SimilarityEngine | None = None,
 ) -> GroupingPlan:
+    _raise_if_grouping_cancelled(should_continue)
     mode_value = GroupingMode(mode)
     valid_items = [
         item for item in items if isinstance(item, dict) and item.get("path")
@@ -915,7 +932,11 @@ def build_grouping_plan(
 
     if mode_value == GroupingMode.LOCATION:
         return _build_location_plan(
-            total_items, image_paths, skipped_paths, location_depth
+            total_items,
+            image_paths,
+            skipped_paths,
+            location_depth,
+            should_continue=should_continue,
         )
     if mode_value == GroupingMode.FACE:
         return _build_face_plan(
@@ -923,6 +944,7 @@ def build_grouping_plan(
             image_paths,
             skipped_paths,
             image_pipeline=image_pipeline,
+            should_continue=should_continue,
         )
     if mode_value == GroupingMode.MIXED:
         return _build_mixed_plan(
@@ -931,6 +953,8 @@ def build_grouping_plan(
             skipped_paths,
             progress_callback=progress_callback,
             image_pipeline=image_pipeline,
+            should_continue=should_continue,
+            similarity_engine=similarity_engine,
         )
     return _build_similarity_plan(
         total_items,
@@ -938,6 +962,8 @@ def build_grouping_plan(
         skipped_paths,
         progress_callback=progress_callback,
         image_pipeline=image_pipeline,
+        should_continue=should_continue,
+        similarity_engine=similarity_engine,
     )
 
 
@@ -991,12 +1017,17 @@ def _build_similarity_plan(
     skipped_paths: Sequence[str],
     progress_callback=None,
     image_pipeline: ImagePipeline | None = None,
+    should_continue: Callable[[], bool] | None = None,
+    similarity_engine: SimilarityEngine | None = None,
 ) -> GroupingPlan:
-    assignments = _run_ml_similarity_pipeline(
-        image_paths,
-        progress_callback=progress_callback,
-        image_pipeline=image_pipeline,
-    )
+    pipeline_kwargs = {
+        "progress_callback": progress_callback,
+        "shared_engine": similarity_engine,
+        "image_pipeline": image_pipeline,
+    }
+    if should_continue is not None:
+        pipeline_kwargs["should_continue"] = should_continue
+    assignments = _run_ml_similarity_pipeline(image_paths, **pipeline_kwargs)
     grouped_paths = set(assignments.keys())
     unassigned = sorted([path for path in image_paths if path not in grouped_paths])
     groups = _build_groups_from_assignments(
@@ -1017,10 +1048,12 @@ def _build_face_plan(
     image_paths: Sequence[str],
     skipped_paths: Sequence[str],
     image_pipeline: ImagePipeline | None = None,
+    should_continue: Callable[[], bool] | None = None,
 ) -> GroupingPlan:
     vectors: dict[str, np.ndarray] = {}
     unassigned: list[str] = []
     for path in image_paths:
+        _raise_if_grouping_cancelled(should_continue)
         vector, has_face_like_signal = _compute_face_vector(
             path,
             image_pipeline=image_pipeline,
@@ -1050,10 +1083,12 @@ def _build_location_plan(
     image_paths: Sequence[str],
     skipped_paths: Sequence[str],
     location_depth: int = 3,
+    should_continue: Callable[[], bool] | None = None,
 ) -> GroupingPlan:
     buckets: dict[str, list[str]] = {}
     unassigned: list[str] = []
     for path in image_paths:
+        _raise_if_grouping_cancelled(should_continue)
         metadata = _load_comprehensive_metadata(path)
         label = _location_label_from_metadata(metadata, depth=location_depth)
         if not label:
@@ -1105,10 +1140,13 @@ def _build_mixed_plan(
     skipped_paths: Sequence[str],
     progress_callback=None,
     image_pipeline: ImagePipeline | None = None,
+    should_continue: Callable[[], bool] | None = None,
+    similarity_engine: SimilarityEngine | None = None,
 ) -> GroupingPlan:
     date_buckets: dict[str, list[str]] = {}
     undated: list[str] = []
     for path in image_paths:
+        _raise_if_grouping_cancelled(should_continue)
         label = _extract_date_label(path)
         if not label:
             undated.append(path)
@@ -1118,6 +1156,7 @@ def _build_mixed_plan(
     groups: list[GroupingGroup] = []
     group_counter = 1
     for date_label in sorted(date_buckets.keys()):
+        _raise_if_grouping_cancelled(should_continue)
         bucket_paths = date_buckets[date_label]
 
         def _bucket_progress(
@@ -1126,10 +1165,16 @@ def _build_mixed_plan(
             if progress_callback:
                 progress_callback(percent, f"{bucket_label}: {message}")
 
+        pipeline_kwargs = {
+            "progress_callback": (_bucket_progress if progress_callback else None),
+            "shared_engine": similarity_engine,
+            "image_pipeline": image_pipeline,
+        }
+        if should_continue is not None:
+            pipeline_kwargs["should_continue"] = should_continue
         assignments = _run_ml_similarity_pipeline(
             bucket_paths,
-            progress_callback=_bucket_progress if progress_callback else None,
-            image_pipeline=image_pipeline,
+            **pipeline_kwargs,
         )
         grouped_by_cluster: dict[int, list[str]] = {}
         for path, cluster_id in assignments.items():

--- a/src/core/similarity_engine.py
+++ b/src/core/similarity_engine.py
@@ -16,6 +16,7 @@ from core.similarity_embedding_model import (
     SimilarityModelNotInstalledError,
 )
 from core.similarity_utils import (
+    SimilarityAnalysisCancelled,
     build_regional_distance_matrix,
     adaptive_dbscan_eps,
     build_orientation_map,
@@ -36,6 +37,16 @@ logger = logging.getLogger(__name__)
 
 _module_init_start_time = time.time()
 logger.debug("Initializing SimilarityEngine module...")
+
+
+def _analysis_stop_requested(engine: object) -> bool:
+    """Read the cooperative stop flag without requiring an initialized QObject."""
+
+    try:
+        state = object.__getattribute__(engine, "__dict__")
+    except AttributeError:
+        return False
+    return not state.get("_is_running", True)
 
 
 class SimilarityEngine(QObject):
@@ -67,7 +78,7 @@ class SimilarityEngine(QObject):
             allow_download=allow_model_download,
             progress_callback=self._handle_model_progress,
         )
-        self._is_running = False
+        self._is_running = True
         self._cache_filename = f"embeddings_{self.model.cache_key}.pkl.zst"
         self._region_cache_filename = (
             f"embeddings_{self.model.region_cache_key}.pkl.zst"
@@ -268,7 +279,10 @@ class SimilarityEngine(QObject):
             self.error.emit(f"Could not save regional embeddings cache: {e}")
 
     def generate_embeddings_for_files(self, file_paths: list[str]):
-        self._is_running = True
+        if not self._is_running:
+            logger.info("Similarity analysis skipped (stop already requested).")
+            self.clustering_complete.emit({})
+            return
         logger.info(f"Starting embedding generation for {len(file_paths)} files.")
 
         if not self._load_model():
@@ -408,7 +422,15 @@ class SimilarityEngine(QObject):
         if self._is_running:  # Only cluster if not stopped
             # Build orientation map for orientation-aware clustering
             logger.info("Building orientation map for %d files...", len(file_paths))
-            orientation_map = build_orientation_map(file_paths)
+            try:
+                orientation_map = build_orientation_map(
+                    file_paths,
+                    should_cancel=lambda: _analysis_stop_requested(self),
+                )
+            except SimilarityAnalysisCancelled:
+                logger.info("Orientation mapping cancelled.")
+                self.clustering_complete.emit({})
+                return
             self.cluster_embeddings(
                 final_embeddings_for_requested_files,
                 orientation_map,
@@ -426,7 +448,10 @@ class SimilarityEngine(QObject):
     ) -> np.ndarray:
         """Build a distance matrix from corresponding large image regions."""
         return build_regional_distance_matrix(
-            embeddings, regional_embeddings, subset_paths
+            embeddings,
+            regional_embeddings,
+            subset_paths,
+            should_cancel=lambda: _analysis_stop_requested(self),
         )
 
     def _run_dbscan_on_subset(
@@ -449,6 +474,8 @@ class SimilarityEngine(QObject):
         """
         if not subset_paths:
             return {}, start_cluster_id
+        if _analysis_stop_requested(self):
+            raise SimilarityAnalysisCancelled
 
         subset_embeddings = [embeddings[path] for path in subset_paths]
         embedding_matrix = np.array(subset_embeddings, dtype=np.float32)
@@ -462,6 +489,8 @@ class SimilarityEngine(QObject):
             distance_matrix = self._build_regional_distance_matrix(
                 embeddings, regional_embeddings, subset_paths
             )
+            if _analysis_stop_requested(self):
+                raise SimilarityAnalysisCancelled
             adaptive_eps = base_eps
             dbscan = DBSCAN(
                 eps=adaptive_eps,
@@ -477,6 +506,8 @@ class SimilarityEngine(QObject):
                 eps=adaptive_eps, min_samples=DBSCAN_MIN_SAMPLES, metric="cosine"
             )
             dbscan_labels = dbscan.fit_predict(embedding_matrix)
+        if _analysis_stop_requested(self):
+            raise SimilarityAnalysisCancelled
 
         # Map DBSCAN labels to our cluster IDs
         label_map: dict[int, int] = {}
@@ -553,6 +584,8 @@ class SimilarityEngine(QObject):
                         "Portrait clustering: %d clusters/groups formed.",
                         len(set(portrait_clusters.values())),
                     )
+                    if not self._is_running:
+                        raise SimilarityAnalysisCancelled
                 else:
                     next_id = 1
 
@@ -575,6 +608,10 @@ class SimilarityEngine(QObject):
                     [path_to_cluster[path] for path in filepaths], dtype=int
                 )
 
+            except SimilarityAnalysisCancelled:
+                logger.info("Similarity clustering cancelled.")
+                self.clustering_complete.emit({})
+                return
             except Exception as e_dbscan:
                 error_msg = (
                     f"Error during orientation-aware DBSCAN clustering: {e_dbscan}"
@@ -592,13 +629,18 @@ class SimilarityEngine(QObject):
 
             labels = None
             base_eps = get_similarity_clustering_eps()
-            regional_distance_matrix = (
-                self._build_regional_distance_matrix(
-                    embeddings, regional_embeddings, filepaths
+            try:
+                regional_distance_matrix = (
+                    self._build_regional_distance_matrix(
+                        embeddings, regional_embeddings, filepaths
+                    )
+                    if regional_embeddings
+                    else None
                 )
-                if regional_embeddings
-                else None
-            )
+            except SimilarityAnalysisCancelled:
+                logger.info("Similarity clustering cancelled.")
+                self.clustering_complete.emit({})
+                return
             adaptive_eps = (
                 base_eps
                 if regional_distance_matrix is not None

--- a/src/core/similarity_utils.py
+++ b/src/core/similarity_utils.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from typing import Literal
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 import numpy as np
 from PIL import Image
@@ -10,6 +10,10 @@ from PIL.ImageOps import exif_transpose
 logger = logging.getLogger(__name__)
 
 Orientation = Literal["portrait", "landscape", "square"]
+
+
+class SimilarityAnalysisCancelled(Exception):
+    """Raised when a cancellable similarity computation is asked to stop."""
 
 
 def cosine_similarity(
@@ -112,7 +116,10 @@ def classify_orientation(image_path: str) -> Orientation:
         return "landscape"
 
 
-def build_orientation_map(file_paths: list[str]) -> dict[str, Orientation]:
+def build_orientation_map(
+    file_paths: list[str],
+    should_cancel: Callable[[], bool] | None = None,
+) -> dict[str, Orientation]:
     """
     Build a mapping of file paths to their orientations.
 
@@ -124,6 +131,8 @@ def build_orientation_map(file_paths: list[str]) -> dict[str, Orientation]:
     """
     orientation_map: dict[str, Orientation] = {}
     for path in file_paths:
+        if should_cancel is not None and should_cancel():
+            raise SimilarityAnalysisCancelled
         orientation_map[path] = classify_orientation(path)
     return orientation_map
 
@@ -165,10 +174,18 @@ def build_regional_distance_matrix(
     embeddings: dict[str, list[float]],
     regional_embeddings: dict[str, list[list[float]]],
     subset_paths: list[str],
+    should_cancel: Callable[[], bool] | None = None,
 ) -> np.ndarray:
-    """Build a symmetric distance matrix from shared regional embedding data."""
+    """Build a symmetric distance matrix from shared regional embedding data.
+
+    The matrix is quadratic in the number of images, so callers running in a
+    worker thread can provide a cancellation predicate. It is checked once per
+    row to keep cancellation responsive without adding work to every pair.
+    """
     region_sets: list[np.ndarray] = []
     for path in subset_paths:
+        if should_cancel is not None and should_cancel():
+            raise SimilarityAnalysisCancelled
         region_vectors = regional_embeddings.get(path)
         if region_vectors:
             region_matrix = np.asarray(region_vectors, dtype=np.float32)
@@ -181,6 +198,8 @@ def build_regional_distance_matrix(
     count = len(subset_paths)
     distances = np.zeros((count, count), dtype=np.float32)
     for first_index in range(count):
+        if should_cancel is not None and should_cancel():
+            raise SimilarityAnalysisCancelled
         for second_index in range(first_index + 1, count):
             distance = regional_embedding_distance(
                 region_sets[first_index], region_sets[second_index]

--- a/src/ui/app_controller.py
+++ b/src/ui/app_controller.py
@@ -154,10 +154,16 @@ class AppController(QObject):
         self._pick_best_pending_after_similarity: bool = False
         self._easy_delete_pending_after_similarity: bool = False
         self._pending_grouping_preview: tuple[object, str] | None = None
+        self._pending_grouping_preview_start: (
+            tuple[list[dict[str, Any]], str, str | None, int] | None
+        ) = None
         self._cancelled_workflows: set[str] = set()
         self._ignore_similarity_results = False
         self._pending_exif_cache_capacity_warning: tuple[int, int, int] | None = None
         self._pending_folder_load: tuple[str, dict[str, bool]] | None = None
+        self._pending_folder_load_after_workers: tuple[str, dict[str, bool]] | None = (
+            None
+        )
 
     def is_workflow_analysis_running(self, workflow: str) -> bool:
         if workflow == "organize":
@@ -180,24 +186,25 @@ class AppController(QObject):
         """Cancel only work owned by the departing workflow."""
         self._cancelled_workflows.add(workflow)
         if workflow == "organize":
-            self.worker_manager.stop_grouping_preview()
+            self.worker_manager.request_stop_grouping_preview()
             self._pending_grouping_preview = None
+            self._pending_grouping_preview_start = None
         elif workflow == "easy_delete":
             depended_on_similarity = self._easy_delete_pending_after_similarity
             self._easy_delete_pending_after_similarity = False
-            self.worker_manager.stop_easy_delete_analysis()
+            self.worker_manager.request_stop_easy_delete_analysis()
             if depended_on_similarity:
                 self._ignore_similarity_results = True
-                self.worker_manager.stop_similarity_analysis()
+                self.worker_manager.request_stop_similarity_analysis()
         elif workflow == "pick_best":
             depended_on_similarity = self._pick_best_pending_after_similarity
             self._pick_best_pending_after_similarity = False
-            self.worker_manager.stop_pick_best_analysis()
+            self.worker_manager.request_stop_pick_best_analysis()
             if depended_on_similarity:
                 self._ignore_similarity_results = True
-                self.worker_manager.stop_similarity_analysis()
+                self.worker_manager.request_stop_similarity_analysis()
         elif workflow == "fix_rotation":
-            self.worker_manager.stop_fix_rotation_detection()
+            self.worker_manager.request_stop_fix_rotation_detection()
 
     def _sync_active_image(self, workflow_step: str) -> None:
         controller = getattr(self.main_window, "active_image_controller", None)
@@ -383,6 +390,18 @@ class AppController(QObject):
                 4000,
             )
             return
+        if self.worker_manager.is_rotation_application_running():
+            self.main_window.statusBar().showMessage(
+                "Rotations are still being written. Wait before loading another folder.",
+                4000,
+            )
+            return
+        if self.worker_manager.is_rating_writer_running():
+            self.main_window.statusBar().showMessage(
+                "Ratings are still being written. Wait before loading another folder.",
+                4000,
+            )
+            return
 
         marked_files = self.app_state.get_marked_files()
         preserved_marks = set(marked_files) if preserve_deletion_marks else set()
@@ -427,7 +446,26 @@ class AppController(QObject):
         add_recent_folder(folder_path)
         self.main_window.menu_manager.update_recent_folders_menu()
 
-        self.worker_manager.stop_all_workers()
+        self.worker_manager.request_stop_all_workers()
+        is_any_worker_active = getattr(
+            self.worker_manager,
+            "is_any_worker_active",
+            self.worker_manager.is_any_worker_running,
+        )
+        if is_any_worker_active():
+            self._pending_folder_load_after_workers = (
+                folder_path,
+                {
+                    "skip_grouping_step": skip_grouping_step,
+                    "record_as_source": record_as_source,
+                    "preserve_deletion_marks": preserve_deletion_marks,
+                },
+            )
+            self.main_window.update_loading_text(
+                "Stopping background work before scanning the new folder…"
+            )
+            QTimer.singleShot(25, self._finish_folder_load_after_workers)
+            return
 
         self.app_state.clear_all_file_specific_data()
         if preserved_marks:
@@ -489,6 +527,27 @@ class AppController(QObject):
             perform_blur_detection=False,
             blur_threshold=self.main_window.blur_detection_threshold,
         )
+
+    def _finish_folder_load_after_workers(self) -> None:
+        """Resume a folder change after cancellable workers have exited."""
+
+        if getattr(self.main_window, "_shutdown_in_progress", False):
+            self._pending_folder_load_after_workers = None
+            return
+        is_any_worker_active = getattr(
+            self.worker_manager,
+            "is_any_worker_active",
+            self.worker_manager.is_any_worker_running,
+        )
+        if is_any_worker_active():
+            QTimer.singleShot(25, self._finish_folder_load_after_workers)
+            return
+        pending = self._pending_folder_load_after_workers
+        self._pending_folder_load_after_workers = None
+        if pending is None:
+            return
+        folder_path, options = pending
+        self.load_folder(folder_path, **options)
 
     def resume_folder_load_after_deletion(self, successful: bool) -> None:
         pending = self._pending_folder_load
@@ -612,11 +671,50 @@ class AppController(QObject):
             True,
             None,
         )
-        self.worker_manager.start_grouping_preview(
+        request = (
             list(self.app_state.image_files_data),
             mode,
             source_root,
-            location_depth=self.main_window.grouping_step_widget.get_location_depth(),
+            self.main_window.grouping_step_widget.get_location_depth(),
+        )
+        is_grouping_preview_active = getattr(
+            self.worker_manager,
+            "is_grouping_preview_active",
+            self.worker_manager.is_grouping_preview_running,
+        )
+        if is_grouping_preview_active():
+            self._pending_grouping_preview_start = request
+            self.worker_manager.request_stop_grouping_preview()
+            QTimer.singleShot(25, self._start_pending_grouping_preview)
+            return
+        self._pending_grouping_preview_start = None
+        self.worker_manager.start_grouping_preview(
+            request[0],
+            request[1],
+            request[2],
+            location_depth=request[3],
+        )
+
+    def _start_pending_grouping_preview(self) -> None:
+        """Start the latest preview request after the replaced worker exits."""
+
+        is_grouping_preview_active = getattr(
+            self.worker_manager,
+            "is_grouping_preview_active",
+            self.worker_manager.is_grouping_preview_running,
+        )
+        if is_grouping_preview_active():
+            QTimer.singleShot(25, self._start_pending_grouping_preview)
+            return
+        request = self._pending_grouping_preview_start
+        self._pending_grouping_preview_start = None
+        if request is None or _workflow_is_cancelled(self, "organize"):
+            return
+        self.worker_manager.start_grouping_preview(
+            request[0],
+            request[1],
+            request[2],
+            location_depth=request[3],
         )
 
     def activate_grouping_preview(self) -> None:
@@ -1055,7 +1153,7 @@ class AppController(QObject):
             )
             return
 
-        self.worker_manager.stop_best_shot_analysis()
+        self.worker_manager.request_stop_best_shot_analysis()
         self.main_window.hide_loading_overlay()
         self.main_window.menu_manager.stop_best_shots_action.setEnabled(False)
         remaining_clusters = set(self._build_cluster_path_map().keys()) - set(

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -147,6 +147,7 @@ class MainWindow(QMainWindow):
         self._last_filter_search_text: str | None = None
         self._close_after_grouping_save = False
         self._close_after_deletion = False
+        self._shutdown_in_progress = False
         self._pending_workflow_transition: WorkflowTransitionRequest | None = None
         self._pending_deletion_context: dict[str, Any] | None = None
 
@@ -2515,6 +2516,21 @@ class MainWindow(QMainWindow):
     def closeEvent(self, event):
         close_start = time.perf_counter()
         logger.info("Application close requested.")
+        if getattr(self, "_shutdown_in_progress", False):
+            is_any_worker_active = getattr(
+                self.worker_manager,
+                "is_any_worker_active",
+                self.worker_manager.is_any_worker_running,
+            )
+            if is_any_worker_active():
+                event.ignore()
+                return
+            self._shutdown_in_progress = False
+            MetadataIO.shutdown_worker_thread(immediate=True, timeout=0.0)
+            logger.info("Background workers stopped; application close can complete.")
+            event.accept()
+            return
+
         if self.worker_manager.is_grouping_workflow_running():
             event.ignore()
             self.statusBar().showMessage(
@@ -2588,13 +2604,38 @@ class MainWindow(QMainWindow):
 
         self._close_after_grouping_save = False
         logger.info(
-            "Stopping all workers on application close (preflight %.3fs).",
+            "Requesting all workers stop on application close (preflight %.3fs).",
             time.perf_counter() - close_start,
         )
         self.preview_load_controller.shutdown()
-        self.worker_manager.stop_all_workers()  # Use WorkerManager to stop all
-        MetadataIO.shutdown_worker_thread(immediate=True)
+        self.worker_manager.request_stop_all_workers()
+        is_any_worker_active = getattr(
+            self.worker_manager,
+            "is_any_worker_active",
+            self.worker_manager.is_any_worker_running,
+        )
+        if is_any_worker_active():
+            self._shutdown_in_progress = True
+            self.statusBar().showMessage("Stopping background work…", 0)
+            QTimer.singleShot(25, self._finish_close_after_workers)
+            event.ignore()
+            return
+
+        MetadataIO.shutdown_worker_thread(immediate=True, timeout=0.0)
         event.accept()
+
+    def _finish_close_after_workers(self) -> None:
+        """Retry closing through Qt's event loop once worker threads have exited."""
+
+        is_any_worker_active = getattr(
+            self.worker_manager,
+            "is_any_worker_active",
+            self.worker_manager.is_any_worker_running,
+        )
+        if is_any_worker_active():
+            QTimer.singleShot(25, self._finish_close_after_workers)
+            return
+        self.close()
 
     def _get_current_group_sibling_images(
         self, current_image_proxy_idx: QModelIndex

--- a/src/ui/thumbnail_load_coordinator.py
+++ b/src/ui/thumbnail_load_coordinator.py
@@ -31,6 +31,10 @@ class ViewportThumbnailLoader(QObject):
         self._request_timer.setSingleShot(True)
         self._request_timer.setInterval(50)
         self._request_timer.timeout.connect(self._load_requested_paths)
+        self._folder_start_timer = QTimer(self)
+        self._folder_start_timer.setSingleShot(True)
+        self._folder_start_timer.setInterval(50)
+        self._folder_start_timer.timeout.connect(self._start_folder_session)
         self._load_timer = QTimer(self)
         self._load_timer.setSingleShot(True)
         self._load_timer.setInterval(THUMBNAIL_SCROLL_IDLE_MS)
@@ -54,24 +58,37 @@ class ViewportThumbnailLoader(QObject):
         if not self._all_paths or not self._enabled():
             return
         self._session_id = uuid4().hex
+        self.context.set_thumbnail_progress(0, len(self._all_paths), 0, False)
+        self._start_folder_session()
+
+    def _start_folder_session(self) -> None:
+        """Start the current folder session once the previous worker has exited."""
+
+        if not self._session_id or not self._all_paths or not self._enabled():
+            return
+        manager = self.context.worker_manager
+        if manager.is_thumbnail_preload_running():
+            self._folder_start_timer.start()
+            return
         visible = [
             path
             for path in dict.fromkeys(self._visible_paths())
             if path in self._all_path_set
         ]
-        self.context.set_thumbnail_progress(0, len(self._all_paths), 0, False)
-        self.context.worker_manager.start_thumbnail_session(
+        if not manager.start_thumbnail_session(
             self._session_id,
             self._all_paths,
             visible,
-        )
+        ):
+            self._folder_start_timer.start()
 
     def reset(self, *, stop_worker: bool = False) -> None:
+        self._folder_start_timer.stop()
         self._load_timer.stop()
         self._layout_retry_timer.stop()
         self._request_timer.stop()
         if stop_worker and self.context.worker_manager.is_thumbnail_preload_running():
-            self.context.worker_manager.stop_thumbnail_preload()
+            self.context.worker_manager.request_stop_thumbnail_preload()
         self._session_id = ""
         self._all_paths = []
         self._all_path_set.clear()

--- a/src/ui/ui_components.py
+++ b/src/ui/ui_components.py
@@ -459,7 +459,8 @@ class BlurDetectionWorker(QObject):
         return self._is_running
 
     def run_detection(self):
-        self._is_running = True
+        if not self._is_running:
+            return
         try:
             from core.image_features.blur_detector import BlurDetector
 
@@ -601,7 +602,9 @@ class SimilarityWorker(QObject):
 
     def run(self):
         """The main method that will be executed in the new thread."""
-        self._is_running = True
+        if not self._is_running:
+            self.finished.emit()
+            return
         try:
             from core.similarity_engine import SimilarityEngine
 
@@ -610,6 +613,10 @@ class SimilarityWorker(QObject):
                 allow_model_download=self.allow_model_download,
                 image_pipeline=self.image_pipeline,
             )
+            if not self._is_running:
+                self.similarity_engine.stop()
+                self.finished.emit()
+                return
 
             # 2. Connect its signals to this worker's signals
             self.similarity_engine.progress_update.connect(self.progress_update)
@@ -639,6 +646,10 @@ class SimilarityWorker(QObject):
 
     def _handle_clustering_complete(self, cluster_results: dict[str, int]) -> None:
         """Apply and persist analysis-cache state before returning to the UI."""
+
+        if not self._is_running:
+            self.finished.emit()
+            return
 
         results = dict(cluster_results or {})
         if self.analysis_cache is not None and self.folder_path:

--- a/src/ui/worker_manager.py
+++ b/src/ui/worker_manager.py
@@ -21,6 +21,28 @@ sip = _sip
 
 logger = logging.getLogger(__name__)
 
+_WORKER_SLOTS = (
+    ("scanner_thread", "file_scanner"),
+    ("similarity_thread", "similarity_worker"),
+    ("blur_detection_thread", "blur_detection_worker"),
+    ("rating_loader_thread", "rating_loader_worker"),
+    ("rotation_detection_thread", "rotation_detection_worker"),
+    ("rating_writer_thread", "rating_writer_worker"),
+    ("rotation_application_thread", "rotation_application_worker"),
+    ("thumbnail_preload_thread", "thumbnail_preload_worker"),
+    ("preview_warm_thread", "preview_warm_worker"),
+    ("cuda_detection_thread", "cuda_detection_worker"),
+    ("update_check_thread", "update_check_worker"),
+    ("best_shot_thread", "best_shot_worker"),
+    ("ai_rating_thread", "ai_rating_worker"),
+    ("grouping_preview_thread", "grouping_preview_worker"),
+    ("grouping_workflow_thread", "grouping_workflow_worker"),
+    ("file_deletion_thread", "file_deletion_worker"),
+    ("pick_best_thread", "pick_best_worker"),
+    ("easy_delete_thread", "easy_delete_worker"),
+    ("fix_rotation_detect_thread", "fix_rotation_detect_worker"),
+)
+
 if TYPE_CHECKING:
     from ui.ui_components import (
         BlurDetectionWorker,
@@ -317,19 +339,34 @@ class WorkerManager(QObject):
         if remaining_thread is None:
             setattr(self, worker_attribute, None)
 
-    def _finish_worker_slot(
+    def _request_worker_stop(
         self,
         thread_attribute: str,
         worker_attribute: str,
-        label: str,
+        *,
+        before_stop: Callable[[Any], None] | None = None,
     ) -> None:
-        """Quit a completed worker's event loop, then release its references."""
+        """Request cancellation without waiting on the caller's thread."""
+
+        worker = getattr(self, worker_attribute)
+        if worker is not None and before_stop is not None:
+            try:
+                before_stop(worker)
+            except Exception:
+                logger.debug("Worker pre-stop hook failed.", exc_info=True)
+        stop_method = getattr(worker, "stop", None) if worker is not None else None
+        if stop_method is not None:
+            try:
+                stop_method()
+            except Exception:
+                logger.error(
+                    "Error requesting stop for %s.", worker_attribute, exc_info=True
+                )
 
         thread = getattr(self, thread_attribute)
         if thread is not None and thread.isRunning():
+            thread.requestInterruption()
             thread.quit()
-            thread.wait()
-        self._cleanup_worker_refs(thread_attribute, worker_attribute, label)
 
     def _cleanup_scanner_refs(self):
         self._cleanup_worker_refs("scanner_thread", "file_scanner", "File scanner")
@@ -449,6 +486,10 @@ class WorkerManager(QObject):
     def stop_similarity_analysis(self):
         self._advance_worker_generation("similarity")
         self._stop_worker("similarity_thread", "similarity_worker")
+
+    def request_stop_similarity_analysis(self) -> None:
+        self._advance_worker_generation("similarity")
+        self._request_worker_stop("similarity_thread", "similarity_worker")
 
     def _cleanup_blur_detection_refs(self):
         self._cleanup_worker_refs(
@@ -632,7 +673,8 @@ class WorkerManager(QObject):
     ):
         from workers.grouping_worker import GroupingPreviewWorker
 
-        self.stop_grouping_preview()
+        if self.grouping_preview_thread is not None:
+            return False
         generation = self._advance_worker_generation("grouping_preview")
         self.grouping_preview_thread = QThread()
         self.grouping_preview_worker = GroupingPreviewWorker(
@@ -670,10 +712,15 @@ class WorkerManager(QObject):
         )
         self.grouping_preview_thread.start()
         logger.info("Grouping preview thread started.")
+        return True
 
     def stop_grouping_preview(self):
         self._advance_worker_generation("grouping_preview")
         self._stop_worker("grouping_preview_thread", "grouping_preview_worker")
+
+    def request_stop_grouping_preview(self) -> None:
+        self._advance_worker_generation("grouping_preview")
+        self._request_worker_stop("grouping_preview_thread", "grouping_preview_worker")
 
     def _cleanup_grouping_workflow_refs(self):
         self._cleanup_worker_refs(
@@ -789,10 +836,7 @@ class WorkerManager(QObject):
         )
 
     def is_file_deletion_running(self) -> bool:
-        return (
-            self.file_deletion_thread is not None
-            and self.file_deletion_thread.isRunning()
-        )
+        return self.file_deletion_thread is not None
 
     def stop_all_workers(self):
         logger.info("Stopping all workers...")
@@ -817,56 +861,67 @@ class WorkerManager(QObject):
         self.stop_fix_rotation_detection()
         logger.info("All workers stop requested.")
 
+    def request_stop_all_workers(self) -> None:
+        """Request application-wide cancellation without blocking the UI thread."""
+
+        logger.info("Requesting all workers stop without blocking...")
+        for generation_name in (
+            "similarity",
+            "pick_best",
+            "easy_delete",
+            "fix_rotation",
+            "grouping_preview",
+        ):
+            self._advance_worker_generation(generation_name)
+
+        for thread_attribute, worker_attribute in _WORKER_SLOTS:
+            before_stop = (
+                (lambda worker: worker.disable_emits())
+                if worker_attribute == "rating_loader_worker"
+                else None
+            )
+            self._request_worker_stop(
+                thread_attribute,
+                worker_attribute,
+                before_stop=before_stop,
+            )
+        logger.info("All worker cancellation requests dispatched.")
+
     def is_file_scanner_running(self) -> bool:
-        return self.scanner_thread is not None and self.scanner_thread.isRunning()
+        return self.scanner_thread is not None
 
     def is_similarity_worker_running(self) -> bool:
-        return self.similarity_thread is not None and self.similarity_thread.isRunning()
+        return self.similarity_thread is not None
 
     def is_blur_detection_running(self) -> bool:
-        return (
-            self.blur_detection_thread is not None
-            and self.blur_detection_thread.isRunning()
-        )
+        return self.blur_detection_thread is not None
 
     def is_rating_loader_running(self) -> bool:
-        return (
-            self.rating_loader_thread is not None
-            and self.rating_loader_thread.isRunning()
-        )
+        return self.rating_loader_thread is not None
 
     def is_rotation_detection_running(self) -> bool:
-        return (
-            self.rotation_detection_thread is not None
-            and self.rotation_detection_thread.isRunning()
-        )
+        return self.rotation_detection_thread is not None
 
     def is_cuda_detection_running(self) -> bool:
-        return (
-            self.cuda_detection_thread is not None
-            and self.cuda_detection_thread.isRunning()
-        )
+        return self.cuda_detection_thread is not None
 
     def is_best_shot_worker_running(self) -> bool:
-        return self.best_shot_thread is not None and self.best_shot_thread.isRunning()
+        return self.best_shot_thread is not None
 
     def is_ai_rating_running(self) -> bool:
-        return self.ai_rating_thread is not None and self.ai_rating_thread.isRunning()
+        return self.ai_rating_thread is not None
 
     def is_grouping_preview_running(self) -> bool:
-        return (
-            self.grouping_preview_thread is not None
-            and self.grouping_preview_thread.isRunning()
-        )
+        return self.grouping_preview_thread is not None
+
+    def is_grouping_preview_active(self) -> bool:
+        return self.grouping_preview_thread is not None
 
     def is_grouping_workflow_running(self) -> bool:
-        return (
-            self.grouping_workflow_thread is not None
-            and self.grouping_workflow_thread.isRunning()
-        )
+        return self.grouping_workflow_thread is not None
 
     def is_pick_best_running(self) -> bool:
-        return self.pick_best_thread is not None and self.pick_best_thread.isRunning()
+        return self.pick_best_thread is not None
 
     def start_update_check(self, current_version: str):
         """Start checking for updates in a background thread."""
@@ -887,8 +942,9 @@ class WorkerManager(QObject):
             self.update_check_finished.emit
         )
         self.update_check_worker.update_check_finished.connect(
-            self._cleanup_update_check_worker
+            self.update_check_thread.quit
         )
+        self.update_check_thread.finished.connect(self._cleanup_update_check_worker)
 
         # Connect start signal
         self.update_check_thread.started.connect(
@@ -900,15 +956,12 @@ class WorkerManager(QObject):
 
     def _cleanup_update_check_worker(self):
         """Clean up the update check worker and thread."""
-        self._finish_worker_slot(
+        self._cleanup_worker_refs(
             "update_check_thread", "update_check_worker", "Update check"
         )
 
     def is_update_check_running(self) -> bool:
-        return (
-            self.update_check_thread is not None
-            and self.update_check_thread.isRunning()
-        )
+        return self.update_check_thread is not None
 
     def stop_update_check(self) -> None:
         """Stop an in-flight update check during application shutdown."""
@@ -936,6 +989,14 @@ class WorkerManager(QObject):
             or self.is_pick_best_running()
             or self.is_easy_delete_running()
             or self.is_fix_rotation_running()
+        )
+
+    def is_any_worker_active(self) -> bool:
+        """Whether any worker slot still owns a thread awaiting final cleanup."""
+
+        return any(
+            getattr(self, thread_attribute) is not None
+            for thread_attribute, _worker_attribute in _WORKER_SLOTS
         )
 
     def is_resource_intensive_analysis_running(self) -> bool:
@@ -981,7 +1042,8 @@ class WorkerManager(QObject):
         self.rating_writer_worker.rating_written.connect(self.rating_written.emit)
         self.rating_writer_worker.finished.connect(self.rating_write_finished.emit)
         self.rating_writer_worker.error.connect(self.rating_write_error.emit)
-        self.rating_writer_worker.finished.connect(self._cleanup_rating_writer_worker)
+        self.rating_writer_worker.finished.connect(self.rating_writer_thread.quit)
+        self.rating_writer_thread.finished.connect(self._cleanup_rating_writer_worker)
 
         # Connect start signal
         self.rating_writer_thread.started.connect(
@@ -993,15 +1055,12 @@ class WorkerManager(QObject):
 
     def _cleanup_rating_writer_worker(self):
         """Clean up the rating writer worker and thread."""
-        self._finish_worker_slot(
+        self._cleanup_worker_refs(
             "rating_writer_thread", "rating_writer_worker", "Rating writer"
         )
 
     def is_rating_writer_running(self) -> bool:
-        return (
-            self.rating_writer_thread is not None
-            and self.rating_writer_thread.isRunning()
-        )
+        return self.rating_writer_thread is not None
 
     def stop_rating_writer(self):
         """Stop the rating writer thread."""
@@ -1044,6 +1103,9 @@ class WorkerManager(QObject):
             self.rotation_application_error.emit
         )
         self.rotation_application_worker.finished.connect(
+            self.rotation_application_thread.quit
+        )
+        self.rotation_application_thread.finished.connect(
             self._cleanup_rotation_application_worker
         )
 
@@ -1057,17 +1119,14 @@ class WorkerManager(QObject):
 
     def _cleanup_rotation_application_worker(self):
         """Clean up the rotation application worker and thread."""
-        self._finish_worker_slot(
+        self._cleanup_worker_refs(
             "rotation_application_thread",
             "rotation_application_worker",
             "Rotation application",
         )
 
     def is_rotation_application_running(self) -> bool:
-        return (
-            self.rotation_application_thread is not None
-            and self.rotation_application_thread.isRunning()
-        )
+        return self.rotation_application_thread is not None
 
     def stop_rotation_application(self):
         """Stop the rotation application thread."""
@@ -1083,7 +1142,7 @@ class WorkerManager(QObject):
         """Start one prioritized thumbnail session for the active folder."""
         from workers.thumbnail_preload_worker import ThumbnailPreloadWorker
 
-        if self.is_thumbnail_preload_running():
+        if self.thumbnail_preload_thread is not None:
             return False
 
         self.thumbnail_preload_thread = QThread()
@@ -1109,6 +1168,9 @@ class WorkerManager(QObject):
             self.thumbnail_session_error.emit
         )
         self.thumbnail_preload_worker.session_finished.connect(
+            self.thumbnail_preload_thread.quit
+        )
+        self.thumbnail_preload_thread.finished.connect(
             self._cleanup_thumbnail_preload_worker
         )
         self.thumbnail_preload_thread.started.connect(
@@ -1132,21 +1194,25 @@ class WorkerManager(QObject):
 
     def _cleanup_thumbnail_preload_worker(self, *_args):
         """Clean up the thumbnail preload worker and thread."""
-        self._finish_worker_slot(
+        self._cleanup_worker_refs(
             "thumbnail_preload_thread",
             "thumbnail_preload_worker",
             "Thumbnail preload",
         )
 
     def is_thumbnail_preload_running(self) -> bool:
-        return (
-            self.thumbnail_preload_thread is not None
-            and self.thumbnail_preload_thread.isRunning()
-        )
+        return self.thumbnail_preload_thread is not None
 
     def stop_thumbnail_preload(self):
         """Stop the thumbnail preload thread."""
         self._stop_worker("thumbnail_preload_thread", "thumbnail_preload_worker")
+
+    def request_stop_thumbnail_preload(self) -> None:
+        """Cancel thumbnail warming without blocking the UI thread."""
+
+        self._request_worker_stop(
+            "thumbnail_preload_thread", "thumbnail_preload_worker"
+        )
 
     # --- Folder Preview Warming ---
     def start_preview_warming(self, image_paths: list[str]) -> bool:
@@ -1164,23 +1230,21 @@ class WorkerManager(QObject):
         self.preview_warm_worker.progress.connect(self.preview_warm_progress.emit)
         self.preview_warm_worker.finished.connect(self.preview_warm_finished.emit)
         self.preview_warm_worker.error.connect(self.preview_warm_error.emit)
-        self.preview_warm_worker.finished.connect(self._cleanup_preview_warm_worker)
+        self.preview_warm_worker.finished.connect(self.preview_warm_thread.quit)
+        self.preview_warm_thread.finished.connect(self._cleanup_preview_warm_worker)
         self.preview_warm_thread.started.connect(self.preview_warm_worker.run)
         self.preview_warm_thread.start()
         return True
 
     def _cleanup_preview_warm_worker(self, *_args) -> None:
-        self._finish_worker_slot(
+        self._cleanup_worker_refs(
             "preview_warm_thread",
             "preview_warm_worker",
             "Preview warming",
         )
 
     def is_preview_warming_running(self) -> bool:
-        return (
-            self.preview_warm_thread is not None
-            and self.preview_warm_thread.isRunning()
-        )
+        return self.preview_warm_thread is not None
 
     def stop_preview_warming(self) -> None:
         self._stop_worker("preview_warm_thread", "preview_warm_worker")
@@ -1236,6 +1300,10 @@ class WorkerManager(QObject):
     def stop_pick_best_analysis(self) -> None:
         self._advance_worker_generation("pick_best")
         self._stop_worker("pick_best_thread", "pick_best_worker")
+
+    def request_stop_pick_best_analysis(self) -> None:
+        self._advance_worker_generation("pick_best")
+        self._request_worker_stop("pick_best_thread", "pick_best_worker")
 
     def _cleanup_pick_best_worker(self) -> None:
         self._cleanup_worker_refs(
@@ -1298,10 +1366,12 @@ class WorkerManager(QObject):
         self._advance_worker_generation("easy_delete")
         self._stop_worker("easy_delete_thread", "easy_delete_worker")
 
+    def request_stop_easy_delete_analysis(self) -> None:
+        self._advance_worker_generation("easy_delete")
+        self._request_worker_stop("easy_delete_thread", "easy_delete_worker")
+
     def is_easy_delete_running(self) -> bool:
-        return (
-            self.easy_delete_thread is not None and self.easy_delete_thread.isRunning()
-        )
+        return self.easy_delete_thread is not None
 
     def _cleanup_easy_delete_worker(self) -> None:
         self._cleanup_worker_refs(
@@ -1383,11 +1453,14 @@ class WorkerManager(QObject):
         self._advance_worker_generation("fix_rotation")
         self._stop_worker("fix_rotation_detect_thread", "fix_rotation_detect_worker")
 
-    def is_fix_rotation_running(self) -> bool:
-        return (
-            self.fix_rotation_detect_thread is not None
-            and self.fix_rotation_detect_thread.isRunning()
+    def request_stop_fix_rotation_detection(self) -> None:
+        self._advance_worker_generation("fix_rotation")
+        self._request_worker_stop(
+            "fix_rotation_detect_thread", "fix_rotation_detect_worker"
         )
+
+    def is_fix_rotation_running(self) -> bool:
+        return self.fix_rotation_detect_thread is not None
 
     def _cleanup_fix_rotation_detect_worker(self) -> None:
         self._cleanup_worker_refs(
@@ -1434,6 +1507,9 @@ class WorkerManager(QObject):
 
     def stop_best_shot_analysis(self):
         self._stop_worker("best_shot_thread", "best_shot_worker")
+
+    def request_stop_best_shot_analysis(self) -> None:
+        self._request_worker_stop("best_shot_thread", "best_shot_worker")
 
     def start_ai_rating(
         self,

--- a/src/workers/ai_rating_worker.py
+++ b/src/workers/ai_rating_worker.py
@@ -51,6 +51,7 @@ class AiRatingWorker(QObject):
             min_workers=2, max_workers=6
         )
         self._should_stop = False
+        self._stop_event = threading.Event()
         self._max_retries = max(1, int(max_retries))
         self._retry_delay = max(0.0, float(retry_delay_seconds))
         self._executor_lock = threading.Lock()
@@ -59,6 +60,7 @@ class AiRatingWorker(QObject):
 
     def stop(self) -> None:
         self._should_stop = True
+        self._stop_event.set()
         self._shutdown_executor(cancel=True)
         if self._strategy is not None:
             try:
@@ -118,8 +120,8 @@ class AiRatingWorker(QObject):
                     warning_msg = f"Retry {attempts}/{self._max_retries} for {os.path.basename(image_path)}: {exc}"
                     logger.warning(warning_msg)
                     self.warning.emit(warning_msg)
-                    if delay > 0:
-                        time.sleep(delay)
+                    if delay > 0 and self._stop_event.wait(delay):
+                        return None
         if last_error is not None:
             raise RuntimeError(
                 f"Failed to rate {image_path} after {self._max_retries} attempt(s): {last_error}"

--- a/src/workers/grouping_worker.py
+++ b/src/workers/grouping_worker.py
@@ -4,6 +4,7 @@ from typing import Any
 from PyQt6.QtCore import QObject, pyqtSignal
 
 from core.grouping import (
+    GroupingAnalysisCancelled,
     GroupingMode,
     augment_grouping_plan_with_filesystem_paths,
     build_grouping_output_root,
@@ -38,22 +39,37 @@ class GroupingPreviewWorker(QObject):
         self.location_depth = location_depth
         self.image_pipeline = image_pipeline
         self._should_stop = False
+        self._similarity_engine = None
 
     def stop(self):
         self._should_stop = True
+        if self._similarity_engine is not None:
+            self._similarity_engine.stop()
 
     def run(self):
         try:
             if self._should_stop:
                 return
             self.progress_update.emit(10, "Preparing grouping preview...")
+            mode = GroupingMode(self.mode)
+            if mode in {GroupingMode.SIMILARITY, GroupingMode.MIXED}:
+                from core.similarity_engine import SimilarityEngine
+
+                self._similarity_engine = SimilarityEngine(
+                    image_pipeline=self.image_pipeline
+                )
+                if self._should_stop:
+                    self._similarity_engine.stop()
+                    return
             plan = build_grouping_plan(
                 self.items,
-                GroupingMode(self.mode),
+                mode,
                 progress_callback=self.progress_update.emit,
                 source_root=self.source_root,
                 location_depth=self.location_depth,
                 image_pipeline=self.image_pipeline,
+                should_continue=lambda: not self._should_stop,
+                similarity_engine=self._similarity_engine,
             )
             plan = augment_grouping_plan_with_filesystem_paths(
                 plan,
@@ -63,6 +79,8 @@ class GroupingPreviewWorker(QObject):
                 return
             self.progress_update.emit(100, "Grouping preview ready.")
             self.preview_ready.emit(plan)
+        except GroupingAnalysisCancelled:
+            logger.info("Grouping preview cancelled.")
         except Exception as exc:
             logger.error("Grouping preview failed: %s", exc, exc_info=True)
             self.error.emit(str(exc))

--- a/src/workers/rating_loader_worker.py
+++ b/src/workers/rating_loader_worker.py
@@ -69,7 +69,11 @@ class RatingLoaderWorker(QObject):
             signal.emit(*args)
 
     def run_load(self):
-        self._is_running = True
+        if not self._is_running:
+            logger.info(
+                "Metadata load skipped because cancellation was already requested."
+            )
+            return
         image_paths_to_process = [
             fd["path"]
             for fd in self._image_data_list

--- a/src/workers/rating_writer_worker.py
+++ b/src/workers/rating_writer_worker.py
@@ -44,7 +44,11 @@ class RatingWriterWorker(QObject):
         Args:
             rating_operations: List of tuples (file_path, rating)
         """
-        self._is_running = True
+        if not self._is_running:
+            logger.info(
+                "Rating write skipped because cancellation was already requested"
+            )
+            return
         total_operations = len(rating_operations)
         successful_count = 0
         failed_count = 0

--- a/src/workers/rotation_application_worker.py
+++ b/src/workers/rotation_application_worker.py
@@ -137,7 +137,11 @@ class RotationApplicationWorker(QObject):
         Args:
             approved_rotations: Dict mapping file_path -> rotation_degrees
         """
-        self._is_running = True
+        if not self._is_running:
+            logger.info(
+                "Rotation application skipped because cancellation was already requested"
+            )
+            return
         self._completed_count = 0  # Reset counter
         total_rotations = len(approved_rotations)
         successful_rotations = 0

--- a/tests/test_app_controller_grouping_load.py
+++ b/tests/test_app_controller_grouping_load.py
@@ -32,6 +32,53 @@ def test_load_folder_blocks_while_grouping_workflow_is_running():
     assert "loading another folder" in message
 
 
+def test_load_folder_cancels_analysis_without_blocking(monkeypatch):
+    callbacks = []
+    worker_manager = SimpleNamespace(
+        is_grouping_workflow_running=lambda: False,
+        is_file_deletion_running=lambda: False,
+        is_rotation_application_running=lambda: False,
+        is_rating_writer_running=lambda: False,
+        is_any_worker_running=lambda: True,
+        request_stop_all_workers=Mock(),
+    )
+    app_state = SimpleNamespace(
+        get_marked_files=lambda: [],
+        clear_all_file_specific_data=Mock(),
+    )
+    main_window = SimpleNamespace(
+        show_loading_overlay=Mock(),
+        update_loading_text=Mock(),
+        menu_manager=SimpleNamespace(update_recent_folders_menu=Mock()),
+    )
+    controller = SimpleNamespace(
+        worker_manager=worker_manager,
+        app_state=app_state,
+        main_window=main_window,
+        _pending_folder_load_after_workers=None,
+        _finish_folder_load_after_workers=Mock(),
+    )
+    monkeypatch.setattr("src.ui.app_controller.add_recent_folder", lambda _path: None)
+    monkeypatch.setattr(
+        "src.ui.app_controller.QTimer.singleShot",
+        lambda _delay, callback: callbacks.append(callback),
+    )
+
+    AppController.load_folder(controller, "/tmp/demo")
+
+    worker_manager.request_stop_all_workers.assert_called_once_with()
+    app_state.clear_all_file_specific_data.assert_not_called()
+    assert controller._pending_folder_load_after_workers == (
+        "/tmp/demo",
+        {
+            "skip_grouping_step": False,
+            "record_as_source": True,
+            "preserve_deletion_marks": False,
+        },
+    )
+    assert callbacks == [controller._finish_folder_load_after_workers]
+
+
 def test_handle_grouping_workflow_complete_waits_for_thread_shutdown(monkeypatch):
     status_bar = _DummyStatusBar()
     load_calls = []

--- a/tests/test_grouping_core.py
+++ b/tests/test_grouping_core.py
@@ -1,9 +1,11 @@
 import os
 
 import numpy as np
+import pytest
 from PIL import Image, ImageDraw
 
 from src.core.grouping import (
+    GroupingAnalysisCancelled,
     GroupingMode,
     GroupingGroup,
     GroupingPlan,
@@ -12,6 +14,30 @@ from src.core.grouping import (
     build_grouping_plan,
     execute_grouping_plan,
 )
+
+
+def test_grouping_metadata_modes_honor_cancellation(monkeypatch):
+    loaded = []
+    cancellation_checks = 0
+
+    def should_continue():
+        nonlocal cancellation_checks
+        cancellation_checks += 1
+        return cancellation_checks < 3
+
+    monkeypatch.setattr(
+        "src.core.grouping._load_comprehensive_metadata",
+        lambda path: loaded.append(path) or {},
+    )
+
+    with pytest.raises(GroupingAnalysisCancelled):
+        build_grouping_plan(
+            [{"path": "/tmp/a.jpg"}, {"path": "/tmp/b.jpg"}],
+            GroupingMode.LOCATION,
+            should_continue=should_continue,
+        )
+
+    assert loaded == ["/tmp/a.jpg"]
 
 
 def _create_solid_image(path: str, color: tuple[int, int, int]) -> None:

--- a/tests/test_main_window_grouping_close.py
+++ b/tests/test_main_window_grouping_close.py
@@ -56,7 +56,9 @@ def test_close_without_grouping_edits_skips_expensive_action_preview():
     preview_controller = SimpleNamespace(shutdown=Mock())
     worker_manager = SimpleNamespace(
         is_grouping_workflow_running=lambda: False,
-        stop_all_workers=Mock(),
+        is_file_deletion_running=lambda: False,
+        is_any_worker_running=lambda: False,
+        request_stop_all_workers=Mock(),
     )
     window = SimpleNamespace(
         worker_manager=worker_manager,
@@ -74,5 +76,44 @@ def test_close_without_grouping_edits_skips_expensive_action_preview():
 
     pending_actions.assert_not_called()
     preview_controller.shutdown.assert_called_once()
-    worker_manager.stop_all_workers.assert_called_once()
+    worker_manager.request_stop_all_workers.assert_called_once()
     assert event.accepted
+
+
+def test_close_requests_worker_stop_without_waiting(monkeypatch):
+    callbacks = []
+    status_bar = _DummyStatusBar()
+    preview_controller = SimpleNamespace(shutdown=Mock())
+    worker_manager = SimpleNamespace(
+        is_grouping_workflow_running=lambda: False,
+        is_file_deletion_running=lambda: False,
+        is_any_worker_running=lambda: True,
+        request_stop_all_workers=Mock(),
+    )
+    window = SimpleNamespace(
+        worker_manager=worker_manager,
+        grouping_step_widget=SimpleNamespace(
+            pending_grouping_action_lines=lambda: [],
+            has_unsaved_grouping_edits=lambda: False,
+        ),
+        app_state=SimpleNamespace(get_marked_files=lambda: []),
+        preview_load_controller=preview_controller,
+        statusBar=lambda: status_bar,
+        _close_after_grouping_save=False,
+        _shutdown_in_progress=False,
+        _finish_close_after_workers=Mock(),
+    )
+    event = _DummyEvent()
+    monkeypatch.setattr(
+        "src.ui.main_window.QTimer.singleShot",
+        lambda _delay, callback: callbacks.append(callback),
+    )
+
+    MainWindow.closeEvent(window, event)
+
+    worker_manager.request_stop_all_workers.assert_called_once_with()
+    assert event.ignored
+    assert not event.accepted
+    assert window._shutdown_in_progress is True
+    assert callbacks == [window._finish_close_after_workers]
+    assert status_bar.messages[-1][0] == "Stopping background work…"

--- a/tests/test_rating_writer_worker.py
+++ b/tests/test_rating_writer_worker.py
@@ -28,6 +28,15 @@ class TestRatingWriterWorker:
         assert worker._is_running is False
 
     @patch("workers.rating_writer_worker.MetadataProcessor")
+    def test_stop_before_start_is_not_lost(self, mock_metadata_processor):
+        worker = RatingWriterWorker()
+        worker.stop()
+
+        worker.write_ratings([("/tmp/photo.jpg", 5)])
+
+        mock_metadata_processor.set_rating.assert_not_called()
+
+    @patch("workers.rating_writer_worker.MetadataProcessor")
     def test_write_single_rating_success(self, mock_metadata_processor):
         """Test writing a single rating successfully"""
         mock_metadata_processor.set_rating.return_value = True

--- a/tests/test_rotation_application_worker.py
+++ b/tests/test_rotation_application_worker.py
@@ -28,6 +28,15 @@ class TestRotationApplicationWorker:
         assert worker._is_running is False
 
     @patch("workers.rotation_application_worker.MetadataProcessor")
+    def test_stop_before_start_is_not_lost(self, mock_metadata_processor):
+        worker = RotationApplicationWorker()
+        worker.stop()
+
+        worker.apply_rotations({"/tmp/photo.jpg": 90})
+
+        mock_metadata_processor.try_metadata_rotation_first.assert_not_called()
+
+    @patch("workers.rotation_application_worker.MetadataProcessor")
     def test_apply_single_rotation_clockwise_success(self, mock_metadata_processor):
         """Test applying a single clockwise rotation"""
         # Mock metadata-first rotation success

--- a/tests/test_similarity_engine_helpers.py
+++ b/tests/test_similarity_engine_helpers.py
@@ -6,7 +6,9 @@ pytest.importorskip("sklearn")
 
 from core.similarity_engine import SimilarityEngine
 from core.similarity_utils import (
+    SimilarityAnalysisCancelled,
     adaptive_dbscan_eps,
+    build_orientation_map,
     build_regional_distance_matrix,
     classify_orientation,
     cosine_similarity,
@@ -52,6 +54,46 @@ def test_regional_distance_keeps_identical_ordered_regions_together():
     )
 
     assert distances[0, 1] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_regional_distance_matrix_honors_cancellation():
+    paths = [f"/tmp/{index}.jpg" for index in range(10)]
+    embeddings = {path: [1.0, 0.0] for path in paths}
+    regional_embeddings = {path: [[1.0, 0.0]] for path in paths}
+    cancellation_checks = 0
+
+    def should_cancel():
+        nonlocal cancellation_checks
+        cancellation_checks += 1
+        return cancellation_checks >= 4
+
+    with pytest.raises(SimilarityAnalysisCancelled):
+        build_regional_distance_matrix(
+            embeddings,
+            regional_embeddings,
+            paths,
+            should_cancel=should_cancel,
+        )
+
+    assert cancellation_checks == 4
+
+
+def test_orientation_map_honors_cancellation(monkeypatch):
+    classified_paths = []
+
+    def classify(path):
+        classified_paths.append(path)
+        return "landscape"
+
+    monkeypatch.setattr("core.similarity_utils.classify_orientation", classify)
+
+    with pytest.raises(SimilarityAnalysisCancelled):
+        build_orientation_map(
+            ["/tmp/a.jpg", "/tmp/b.jpg"],
+            should_cancel=lambda: bool(classified_paths),
+        )
+
+    assert classified_paths == ["/tmp/a.jpg"]
 
 
 def test_l2_normalize_rows_produces_unit_norm_rows():

--- a/tests/test_thumbnail_load_coordinator.py
+++ b/tests/test_thumbnail_load_coordinator.py
@@ -43,6 +43,25 @@ def test_folder_session_prioritizes_visible_and_warms_every_path_once():
     context.set_thumbnail_progress.assert_called_once_with(0, 3, 0, False)
 
 
+def test_replacing_folder_session_cancels_without_waiting_and_retries():
+    context = _context(item_count=2)
+    context.worker_manager.is_thumbnail_preload_running.return_value = True
+    loader = ViewportThumbnailLoader(context)
+    loader._visible_paths = Mock(return_value=["image-1.jpg"])
+
+    loader.start_folder(["image-0.jpg", "image-1.jpg"])
+
+    context.worker_manager.request_stop_thumbnail_preload.assert_called_once_with()
+    context.worker_manager.stop_thumbnail_preload.assert_not_called()
+    context.worker_manager.start_thumbnail_session.assert_not_called()
+    assert loader._folder_start_timer.isActive()
+
+    context.worker_manager.is_thumbnail_preload_running.return_value = False
+    loader._start_folder_session()
+
+    context.worker_manager.start_thumbnail_session.assert_called_once()
+
+
 def test_scroll_request_is_reprioritized_while_session_is_active():
     context = _context(item_count=2)
     loader = ViewportThumbnailLoader(context)

--- a/tests/test_worker_manager_lifecycle.py
+++ b/tests/test_worker_manager_lifecycle.py
@@ -38,6 +38,7 @@ def test_any_worker_running_covers_every_managed_workflow(thread_attribute):
     setattr(manager, thread_attribute, thread)
 
     assert manager.is_any_worker_running() is True
+    assert manager.is_any_worker_active() is True
 
 
 def test_stop_update_check_uses_shared_cancellation_path():
@@ -53,3 +54,74 @@ def test_stop_update_check_uses_shared_cancellation_path():
     thread.wait.assert_called_once_with(5000)
     assert manager.update_check_thread is None
     assert manager.update_check_worker is None
+
+
+def test_request_stop_all_workers_never_waits_on_worker_threads():
+    manager = WorkerManager(Mock())
+    manager.similarity_thread = thread = Mock()
+    manager.similarity_worker = worker = Mock()
+    thread.isRunning.return_value = True
+
+    manager.request_stop_all_workers()
+
+    worker.stop.assert_called_once_with()
+    thread.requestInterruption.assert_called_once_with()
+    thread.quit.assert_called_once_with()
+    thread.wait.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("method_name", "thread_attribute", "worker_attribute"),
+    [
+        (
+            "request_stop_similarity_analysis",
+            "similarity_thread",
+            "similarity_worker",
+        ),
+        (
+            "request_stop_grouping_preview",
+            "grouping_preview_thread",
+            "grouping_preview_worker",
+        ),
+        (
+            "request_stop_thumbnail_preload",
+            "thumbnail_preload_thread",
+            "thumbnail_preload_worker",
+        ),
+        (
+            "request_stop_pick_best_analysis",
+            "pick_best_thread",
+            "pick_best_worker",
+        ),
+        (
+            "request_stop_easy_delete_analysis",
+            "easy_delete_thread",
+            "easy_delete_worker",
+        ),
+        (
+            "request_stop_fix_rotation_detection",
+            "fix_rotation_detect_thread",
+            "fix_rotation_detect_worker",
+        ),
+        (
+            "request_stop_best_shot_analysis",
+            "best_shot_thread",
+            "best_shot_worker",
+        ),
+    ],
+)
+def test_ui_cancellation_methods_never_wait(
+    method_name, thread_attribute, worker_attribute
+):
+    manager = WorkerManager(Mock())
+    thread = Mock()
+    worker = Mock()
+    thread.isRunning.return_value = True
+    setattr(manager, thread_attribute, thread)
+    setattr(manager, worker_attribute, worker)
+
+    getattr(manager, method_name)()
+
+    worker.stop.assert_called_once_with()
+    thread.quit.assert_called_once_with()
+    thread.wait.assert_not_called()

--- a/tests/test_workflow_transition_guard.py
+++ b/tests/test_workflow_transition_guard.py
@@ -273,8 +273,8 @@ def test_successful_in_place_resolution_does_not_open_another_workflow():
 
 def test_cancelled_workflow_discards_late_analysis_results():
     worker = SimpleNamespace(
-        stop_easy_delete_analysis=Mock(),
-        stop_similarity_analysis=Mock(),
+        request_stop_easy_delete_analysis=Mock(),
+        request_stop_similarity_analysis=Mock(),
     )
     state = SimpleNamespace(
         easy_delete_results=None,
@@ -293,8 +293,8 @@ def test_cancelled_workflow_discards_late_analysis_results():
     assert state.easy_delete_results is None
     assert state.embeddings_cache == {}
     main_window.easy_delete_step_widget.show_results.assert_not_called()
-    worker.stop_easy_delete_analysis.assert_called_once()
-    worker.stop_similarity_analysis.assert_called_once()
+    worker.request_stop_easy_delete_analysis.assert_called_once()
+    worker.request_stop_similarity_analysis.assert_called_once()
 
 
 def test_worker_generation_drops_callback_from_replaced_run():


### PR DESCRIPTION
Exiting app while loading easy delete etc would freeze the UI, this aims to fix it

- Introduced non-blocking cancellation requests for all worker threads to improve application responsiveness during shutdown and folder loading.
- Added `_shutdown_in_progress` flag to manage shutdown state in `MainWindow`.
- Implemented `_finish_close_after_workers` method to retry closing the application after worker threads have exited.
- Updated `WorkerManager` to include `request_stop_*` methods for various workers, ensuring they can be stopped without blocking the UI.
- Enhanced worker classes (e.g., `AiRatingWorker`, `RatingLoaderWorker`, `RotationApplicationWorker`) to respect cancellation requests and skip processing if already stopped.
- Added tests to verify cancellation behavior and ensure that workers do not block the application during shutdown or folder loading.
- Improved logging for better traceability of worker states and actions.